### PR TITLE
Added Blooms.

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -12,6 +12,7 @@
         "bao": "A traditional mancala-style sowing game from East Africa where you attempt to eliminate all pieces from the opposing front row or leave them with no legal moves.",
         "bide": "Up to six players take turns placing pieces on the board, pushing adjacent pieces outward. One can also pass to build up a number of pieces that can be placed at once later. Pieces closer to the centre are more valuable. Highest-scoring group wins!",
         "blam": "An Icehouse game for 2–4 players played on a standard chess board. Pieces placed push adjacent pieces away. Push pieces off the board to capture them. Whoever has captured the highest pip total of pieces at the end of the game wins.",
+        "blooms": "Each player owns 2 colors of stones. To start, Player 1 places 1 stone of either of her colors on any empty space. From then on, starting with Player 2, the players take turns. On your turn, you must place 1 or 2 stones onto any empty spaces. If you place 2, they must be different colors. Then capture all fenced enemy blooms. The first player to have captured X stones wins.",
         "boom": "A minimalist abstract that combines simple move and capture mechanics with a scoring mechanic. Score by bearing your stacks off the opposing side of the board, but you'll want to reduce your opponent's scoring opportunities at the same time.",
         "bounce": "Manoeuvre your disconnected checkers into a single, orthogonally connected whole.",
         "breakthrough": "One of the simplest \"get to your opponent's home row\" games around. Pieces move and capture like chess pawns. First to the other home row wins. Also includes a \"Bombardment\" variant where instead of regular capture moves, one can detonate a piece, which destroys it and all pieces around it.",
@@ -80,6 +81,7 @@
     "notes": {
         "armadas": "There are known issues with this game on iOS devices.\n\nThis game offers two scenarios:\n\n* The default is each player having two trios of pieces. In the placement phase, each player must place 1 to 3 ships until all ships are placed.\n* The \"Freeform\" variant allows you to place whatever ships you want (maximum of three at a time) until both players \"pass.\" This lets you create unbalanced or otherwise asymmetrical fleets.\n\nGames default to having one island in the centre of the field. Both a \"no islands\" and a \"two islands\" variant are available. You cannot move or fire through islands. To successfully hit a ship, at least one corner of your ship's triangle must have a clear view of at least one corner of the target ship.\n\nRemember that it is possible to get your ship in a position against an island or the edge of the board such that you can no longer move that ship! Be careful!",
         "bao": "Moves in Bao can be very complex, involving multiple laps around the board and changing directions. The annotations are, therefore, sparse. The initial cell and direction are higlighted, and captured cells are also marked. But detailed annotation of movement is not possible. If you believe you have encountered a bug, please let us know in Discord.",
+        "blooms": "The threshold value, X(n) = 5n, where n is the base of the hexhex board.",
         "chase": "Currently, most exchange moves will need to be hand edited. We're working on fixing this.",
         "entropy": "In this implementation, the players play two games simultaneously but with a single shared stream of randomized pieces. Each player places a piece on their *opponent's* Order board and then makes a move on their *own* Order board; players thus act as both Order and Chaos at the same time. The player with the greatest score wins! Since both players had the exact same placement choices, this provides the cleanest measure of relative skill.",
         "exxit": "Because the board is built out as you play in irregular shapes, the hexes are labelled numerically instead of algebraically. We chose this so that the labels wouldn't change as the map grew. Because the labels aren't particularly helpful while you play, they are not displayed on the board.",
@@ -335,6 +337,16 @@
             "NOPIECE": "You do not have a piece of size {{size}} to place.",
             "PARTIAL": "Provide the destination.",
             "SIZEFIRST": "First provide the size of the piece to place. You can click on your stash."
+        },  
+        "blooms": {
+            "INITIAL_INSTRUCTIONS": "Place 1 or 2 pieces on the board. If you place 2 pieces, they must be of different colours.",
+            "INITIAL_INSTRUCTIONS_FIRST": "Place 1 piece of either colour on the board.",
+            "TOO_MANY_MOVES": "You may only place two pieces on the board per turn.",
+            "TOO_MANY_MOVES_FIRST": "You may only place one piece on the board on the first turn.",
+            "INVALIDTILE": "The first character of the move notation has to be '1' or '2' for the tile type.",
+            "PLACE_NEXT": "Click on the recently placed piece to switch colours, or click on another space to place a tile of the other colour.",
+            "SAME_CELL": "Select two different cells to place the tiles.",
+            "SAME_TILE": "You cannot place two tiles of the same type in a the same move."
         },
         "boom": {
             "INITIAL_INSTRUCTIONS": "Select a stack to move or attack with.",
@@ -1053,6 +1065,14 @@
                 "name": "Malawi"
             }
         },
+        "blooms": {
+            "size-8": {
+                "name": "Larger board (base 8)"
+            },
+            "size-10": {
+                "name": "Larger board (base 10)"
+            }
+        },
         "bounce": {
             "10": {
                 "name": "Larger board: 10x10"
@@ -1387,6 +1407,12 @@
             "pips": {
                 "description": "Display the stones as pips instead of as numerals.",
                 "name": "Pips"
+            }
+        },
+        "blooms": {
+            "hide-threatened": {
+                "description": "Don't show threatened stones.",
+                "name": "Hide threatened"
             }
         },
         "tumbleweed": {

--- a/locales/en/apresults.json
+++ b/locales/en/apresults.json
@@ -17,6 +17,7 @@
     "CAPTURE": {
         "bao_one": "{{player}} captured a total of {{count}} stone from the following pits (in order): {{pits}}",
         "bao_other": "{{player}} captured a total of {{count}} stones from the following pits (in order): {{pits}}",
+        "blooms": "{{player}} captured a {{what}} group of size {{count}}.",
         "boom": "{{player}} destroyed a piece at {{where}}.",
         "complete": "{{player}} captured a {{what}} at {{where}}.",
         "furl": "{{player}} captured a stack of size {{size}} at {{where}}.",
@@ -163,6 +164,7 @@
         "armadas_1": "{{player}} placed a small ship and named it {{name}}.",
         "armadas_2": "{{player}} placed a medium ship and named it {{name}}.",
         "armadas_3": "{{player}} placed a large ship and named it {{name}}.",
+        "blooms": "{{player}} placed a {{what}} piece at {{where}}.",
         "cannon": "{{player}} placed their town at {{where}}.",
         "chase": "The chamber spit out a {{what}} at {{where}}.",
         "complete": "{{player}} placed a {{what}} at {{where}}.",

--- a/src/games/blooms.ts
+++ b/src/games/blooms.ts
@@ -1,0 +1,640 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
+import { APGamesInformation } from "../schemas/gameinfo";
+import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
+import { APMoveResult } from "../schemas/moveresults";
+import { reviver, UserFacingError } from "../common";
+import i18next from "i18next";
+import { HexTriGraph } from "../common/graphs";
+
+export type playerid = 1|2;
+export type tileid = 1|2;
+const tileNames = ["dark", "light"];  // For tileid 1 and 2
+
+export interface IMoveState extends IIndividualState {
+    currplayer: playerid;
+    board: Map<string, [playerid, tileid]>;
+    lastmove?: string;
+    scores: number[];
+};
+
+export interface IBloomsState extends IAPGameState {
+    winner: playerid[];
+    stack: Array<IMoveState>;
+};
+
+export class BloomsGame extends GameBase {
+    public static readonly gameinfo: APGamesInformation = {
+        name: "Blooms",
+        uid: "blooms",
+        playercounts: [2],
+        version: "20240114",
+        // i18next.t("apgames:descriptions.blooms")
+        description: "apgames:descriptions.blooms",
+        urls: ["https://www.nickbentley.games/blooms-rules/"],
+        people: [
+            {
+                type: "designer",
+                name: "Nick Bentley",
+                urls: ["https://www.nickbentley.games/"],
+            }
+        ],
+        flags: ["experimental", "multistep", "scores"],
+        variants: [
+            {
+                uid: "size-8",
+                group: "board",
+            },
+            {
+                uid: "size-10",
+                group: "board",
+            },
+        ],
+        displays: [{uid: "hide-threatened"}],
+    };
+
+    public numplayers = 2;
+    public currplayer: playerid = 1;
+    public board!: Map<string, [playerid, tileid]>;
+    public graph: HexTriGraph = new HexTriGraph(7, 13);
+    public gameover = false;
+    public winner: playerid[] = [];
+    public variants: string[] = [];
+    public stack!: Array<IMoveState>;
+    public results: Array<APMoveResult> = [];
+    public scores: number[] = [0, 0];
+    private threshold = 0;
+    private boardSize = 0;
+    private captured: Set<string>[] = [];
+
+    constructor(state?: IBloomsState | string, variants?: string[]) {
+        super();
+        if (state === undefined) {
+            if (variants !== undefined) {
+                this.variants = [...variants];
+            }
+            const fresh: IMoveState = {
+                _version: BloomsGame.gameinfo.version,
+                _results: [],
+                _timestamp: new Date(),
+                currplayer: 1,
+                board: new Map(),
+                scores: [0, 0],
+            };
+            this.stack = [fresh];
+        } else {
+            if (typeof state === "string") {
+                state = JSON.parse(state, reviver) as IBloomsState;
+            }
+            if (state.game !== BloomsGame.gameinfo.uid) {
+                throw new Error(`The Blooms engine cannot process a game of '${state.game}'.`);
+            }
+            this.gameover = state.gameover;
+            this.winner = [...state.winner];
+            this.variants = state.variants;
+            this.stack = [...state.stack];
+        }
+        this.load();
+    }
+
+    public load(idx = -1): BloomsGame {
+        if (idx < 0) {
+            idx += this.stack.length;
+        }
+        if ( (idx < 0) || (idx >= this.stack.length) ) {
+            throw new Error("Could not load the requested state from the stack.");
+        }
+
+        const state = this.stack[idx];
+        this.currplayer = state.currplayer;
+        this.board = new Map(state.board);
+        this.lastmove = state.lastmove;
+        this.results = [...state._results];
+        this.scores = [...state.scores];
+        this.boardSize = this.getBoardSize();
+        this.threshold = this.getThreshold();
+        this.buildGraph();
+        return this;
+    }
+
+    private getBoardSize(): number {
+        // Get board size from variants.
+        if ( (this.variants !== undefined) && (this.variants.length > 0) && (this.variants[0] !== undefined) && (this.variants[0].length > 0) ) {
+            const sizeVariants = this.variants.filter(v => v.includes("size"));
+            if (sizeVariants.length > 0) {
+                const size = sizeVariants[0].match(/\d+/);
+                return parseInt(size![0], 10);
+            }
+            if (isNaN(this.boardSize)) {
+                throw new Error(`Could not determine the board size from variant "${this.variants[0]}"`);
+            }
+        }
+        return 6;
+    }
+
+    private getThreshold(): number {
+        // Get threshold from board size.
+        return this.boardSize * 5;
+        // // Alternative: fraction of number of cells.
+        // const fraction = 0.25;
+        // return Math.floor(fraction * (1 + 3 * this.boardSize * (this.boardSize + 1)));
+    }
+
+    private getGraph(): HexTriGraph {
+        return new HexTriGraph(this.boardSize, this.boardSize * 2 - 1);
+    }
+
+    private buildGraph(): BloomsGame {
+        this.graph = this.getGraph();
+        return this;
+    }
+
+    public moves(player?: playerid): string[] {
+        if (this.gameover) { return []; }
+        if (player === undefined) {
+            player = this.currplayer;
+        }
+
+        const moves: string[] = [];
+        const empties = (this.graph.listCells() as string[]).filter(c => ! this.board.has(c)).sort();
+        // Get singles
+        for (const cell of empties) {
+            moves.push("1" + cell);
+            moves.push("2" + cell);
+        }
+        // Get doubles
+        if (this.stack.length > 1) {
+            for (let i = 0; i < empties.length; i++) {
+                for (let j = 0; j < empties.length; j++) {
+                    if (i === j) { continue; }
+                    moves.push(`1${empties[i]},2${empties[j]}`);
+                }
+            }
+        }
+        return moves;
+    }
+
+    public randomMove(): string {
+        const moves = this.moves();
+        return moves[Math.floor(Math.random() * moves.length)];
+    }
+
+    private splitTileCell(move: string): [tileid, string] {
+        // Split the move into tile and cell.
+        const tile = parseInt(move[0], 10);
+        const cell = move.slice(1);
+        if (tile !== 1 && tile !== 2) {
+            throw new Error(`Invalid tile: ${tile}`);
+        }
+        return [tile as tileid, cell];
+    }
+
+    public handleClick(move: string, row: number, col: number, piece?: string): IClickResult {
+        try {
+            let newmove = "";
+            const cell = this.graph.coords2algebraic(col, row);
+            if (move === "") {
+                newmove = `1${cell}`;
+            } else {
+                const moves = move.split(",");
+                if (moves.length === 1) {
+                    const [tile, oldCell] = this.splitTileCell(moves[0]);
+                    if (oldCell === cell) {
+                        // Swap tile.
+                        newmove = `${tile % 2 + 1}${cell}`;
+                    } else if (tile === 1) {
+                        newmove = `${moves[0]},2${cell}`;
+                    } else {
+                        newmove = `1${cell},${moves[0]}`;
+                    }
+                } else {
+                    const [, cell1] = this.splitTileCell(moves[0]);
+                    const [, cell2] = this.splitTileCell(moves[1]);
+                    if (cell1 === cell || cell2 === cell) {
+                        // Swap tiles.
+                        newmove = `1${cell2},2${cell1}`;
+                    } else {
+                        return {
+                            move,
+                            valid: false,
+                            message: i18next.t("apgames:validation.blooms.TOO_MANY_MOVES"),
+                        };
+                    }
+                }
+            }
+            const result = this.validateMove(newmove) as IClickResult;
+            if (!result.valid) {
+                result.move = move;
+            } else {
+                result.move = newmove;
+            }
+            return result;
+        } catch (e) {
+            return {
+                move,
+                valid: false,
+                message: i18next.t("apgames:validation._general.GENERIC", {move, row, col, piece, emessage: (e as Error).message})
+            };
+        }
+    }
+
+    private normaliseMove(move: string): string {
+        // Normalise a move by sorting the cells.
+        move = move.toLowerCase();
+        move = move.replace(/\s+/g, "");
+        const moves = move.split(",").sort();
+        return moves.join(",");
+    }
+
+    public sameMove(move1: string, move2: string): boolean {
+        // Check if two moves are the same.
+        return this.normaliseMove(move1) === this.normaliseMove(move2);
+    }
+
+    public validateMove(m: string): IValidationResult {
+        const result: IValidationResult = {valid: false, message: i18next.t("apgames:validation._general.DEFAULT_HANDLER")};
+        if (m.length === 0) {
+            if (this.stack.length === 1) {
+                result.valid = true;
+                result.complete = -1;
+                result.canrender = true;
+                result.message = i18next.t("apgames:validation.blooms.INITIAL_INSTRUCTIONS_FIRST");
+                return result;
+            }
+            result.valid = true;
+            result.complete = -1;
+            result.canrender = true;
+            result.message = i18next.t("apgames:validation.blooms.INITIAL_INSTRUCTIONS");
+            return result;
+        }
+
+        m = this.normaliseMove(m);
+        const moves = m.split(",");
+        // Don't exceed count
+        if (moves.length > 2) {
+            result.valid = false;
+            result.message = i18next.t("apgames:validation.blooms.TOO_MANY_MOVES");
+            return result;
+        }
+        if (this.stack.length === 1 && moves.length > 1) {
+            result.valid = false;
+            result.message = i18next.t("apgames:validation.blooms.TOO_MANY_MOVES_FIRST");
+            return result;
+        }
+
+        // Valid tile
+        let badTile;
+        for (const move of moves) {
+            const tile = move[0];
+            if (tile !== "1" && tile !== "2") {
+                badTile = tile;
+                break;
+            }
+        }
+        if (badTile) {
+            result.valid = false;
+            result.message = i18next.t("apgames:validation.blooms.INVALIDTILE", {cell: badTile});
+            return result;
+        }
+
+        // Valid cell
+        let currentMove;
+        try {
+            for (const move of moves) {
+                currentMove = move
+                const [, checkCell] = this.splitTileCell(move);
+                this.graph.algebraic2coords(checkCell);
+            }
+        } catch {
+            result.valid = false;
+            result.message = i18next.t("apgames:validation._general.INVALIDCELL", {cell: currentMove});
+            return result;
+        }
+
+        // Cell is empty
+        let notEmpty;
+        for (const move of moves) {
+            const [, checkCell] = this.splitTileCell(move);
+            if (this.board.has(checkCell)) { notEmpty = checkCell; break; }
+        }
+        if (notEmpty) {
+            result.valid = false;
+            result.message = i18next.t("apgames:validation._general.OCCUPIED", {where: notEmpty});
+            return result;
+        }
+
+        // No duplicate cells.
+        const [move1, move2] = moves;
+        if (move2 === undefined) {
+            if (this.stack.length > 1) {
+                result.valid = true;
+                result.complete = 0;
+                result.canrender = true;
+                result.message = i18next.t("apgames:validation.blooms.PLACE_NEXT");
+                return result;
+            }
+        } else {
+            const [tile1, cell1] = this.splitTileCell(move1);
+            const [tile2, cell2] = this.splitTileCell(move2);
+            if (cell1 === cell2) {
+                result.valid = false;
+                result.message = i18next.t("apgames:validation.blooms.SAME_CELL", {where: cell1});
+                return result;
+            }
+            if (tile1 === tile2) {
+                result.valid = false;
+                result.message = i18next.t("apgames:validation.blooms.SAME_TILE", {tile: tile1});
+                return result;
+            }
+        }
+
+        // we're good
+        result.valid = true;
+        result.complete = 1;
+        result.message = i18next.t("apgames:validation._general.VALID_MOVE");
+        return result;
+    }
+
+    public move(m: string, { partial = false, trusted = false } = {}): BloomsGame {
+        if (this.gameover) {
+            throw new UserFacingError("MOVES_GAMEOVER", i18next.t("apgames:MOVES_GAMEOVER"));
+        }
+
+        m = this.normaliseMove(m);
+        const moves = m.split(",");
+
+        if (!trusted) {
+            const result = this.validateMove(m);
+            if (!result.valid) {
+                throw new UserFacingError("VALIDATION_GENERAL", result.message)
+            }
+            if (!partial && !this.moves().includes(m)) {
+                throw new UserFacingError("VALIDATION_FAILSAFE", i18next.t("apgames:validation._general.FAILSAFE", {move: m}))
+            }
+        }
+
+        this.results = [];
+        for (const move of moves) {
+            const [tile, cell] = this.splitTileCell(move);
+            this.board.set(cell, [this.currplayer, tile]);
+            this.results.push({type: "place", where: cell, what: tile === 1 ? tileNames[0] : tileNames[1]});
+        }
+        this.captured = this.toCapture(this.currplayer % 2 + 1 as playerid);
+        if (partial) { return this; }
+        const threatenedGroups = this.captured;
+        for (const group of threatenedGroups) {
+            // get tile of arbitrary member
+            const [, tile] = this.board.get(group.values().next().value as string)!;
+            for (const cell of group) {
+                this.board.delete(cell);
+            }
+            this.results.push({type: "capture", where: Array.from(group).join(","), what: tile === 1 ? tileNames[0] : tileNames[1], count: group.size});
+            this.scores[this.currplayer - 1] += group.size;
+        }
+
+        this.lastmove = m;
+        this.currplayer = this.currplayer % 2 + 1 as playerid;
+        this.checkEOG();
+        this.saveState();
+        return this;
+    }
+
+    private pieces(player: playerid, tile: tileid): string[] {
+        // Get all pieces owned by `player` and is `tile`.
+        return [...this.board.entries()].filter(e => (e[1][0] === player) && (e[1][1] === tile)).map(e => e[0]);
+    }
+
+    private getGroups(player: playerid, tile: tileid): Set<string>[] {
+        // Get groups of cells that are connected to `cell` and owned by `player` and is `tile`.
+        const groups: Set<string>[] = [];
+        const pieces = this.pieces(player, tile);
+        const seen: Set<string> = new Set();
+        for (const piece of pieces) {
+            if (seen.has(piece)) {
+                continue;
+            }
+            const group: Set<string> = new Set();
+            const todo: string[] = [piece]
+            while (todo.length > 0) {
+                const cell = todo.pop()!;
+                if (seen.has(cell)) {
+                    continue;
+                }
+                group.add(cell);
+                seen.add(cell);
+                const neighbours = this.graph.neighbours(cell);
+                for (const n of neighbours) {
+                    if (pieces.includes(n)) {
+                        todo.push(n);
+                    }
+                }
+            }
+            groups.push(group);
+        }
+        return groups;
+    }
+
+    private toCapture(player: playerid): Set<string>[] {
+        // Get all pieces owned by `player` that are captured.
+        const captured: Set<string>[] = [];
+        for (const tile of [1, 2] as tileid[]) {
+            const groups = this.getGroups(player, tile);
+            loop:
+            for (const group of groups) {
+                for (const cell of group) {
+                    for (const n of this.graph.neighbours(cell)) {
+                        if (!this.board.has(n)) { continue loop; }
+                    }
+                }
+                captured.push(group);
+            }
+        }
+        return captured;
+    }
+
+    protected checkEOG(): BloomsGame {
+        const prevPlayer = this.currplayer % 2 + 1 as playerid;
+        if (this.scores[prevPlayer - 1] >= this.threshold) {
+            this.gameover = true;
+            this.winner = [prevPlayer];
+        }
+
+        if (this.gameover) {
+            this.results.push(
+                {type: "eog"},
+                {type: "winners", players: [...this.winner]}
+            );
+        }
+
+        return this;
+    }
+
+    public state(): IBloomsState {
+        return {
+            game: BloomsGame.gameinfo.uid,
+            numplayers: this.numplayers,
+            variants: this.variants,
+            gameover: this.gameover,
+            winner: [...this.winner],
+            stack: [...this.stack],
+        };
+    }
+
+    public moveState(): IMoveState {
+        return {
+            _version: BloomsGame.gameinfo.version,
+            _results: [...this.results],
+            _timestamp: new Date(),
+            currplayer: this.currplayer,
+            lastmove: this.lastmove,
+            board: new Map(this.board),
+            scores: [...this.scores],
+        };
+    }
+
+    public render(opts?: { altDisplay: string | undefined }): APRenderRep {
+        let altDisplay: string | undefined;
+        if (opts !== undefined) {
+            altDisplay = opts.altDisplay;
+        }
+        let showThreatened = true;
+        if (altDisplay !== undefined) {
+            if (altDisplay === "hide-threatened") {
+                showThreatened = false;
+            }
+        }
+        // Build piece string
+        const captured: Set<string> = showThreatened ? this.captured.reduce((a, b) => new Set([...a, ...b]), new Set()) : new Set();
+        const pstr: string[][] = [];
+        const cells = this.graph.listCells(true);
+        for (const row of cells) {
+            const pieces: string[] = [];
+            for (const cell of row) {
+                if (this.board.has(cell)) {
+                    const [player, tile] = this.board.get(cell)!;
+                    if (player === 1) {
+                        if (showThreatened && captured.has(cell)) {
+                            if (tile === 1) {
+                                pieces.push("E");
+                            } else {
+                                pieces.push("F");
+                            }
+                        } else {
+                            if (tile === 1) {
+                                pieces.push("A");
+                            } else {
+                                pieces.push("B");
+                            }
+
+                        }
+                    } else {
+                        if (showThreatened && captured.has(cell)) {
+                            if (tile === 1) {
+                                pieces.push("G");
+                            } else {
+                                pieces.push("H");
+                            }
+                        } else {
+                            if (tile === 1) {
+                                pieces.push("C");
+                            } else {
+                                pieces.push("D");
+                            }
+
+                        }
+                    }
+                } else {
+                    pieces.push("-");
+                }
+            }
+            pstr.push(pieces);
+        }
+
+        // Build rep
+        const rep: APRenderRep =  {
+            board: {
+                style: "hex-of-hex",
+                minWidth: this.boardSize,
+                maxWidth: (this.boardSize * 2) - 1,
+            },
+            legend: {
+                A: [{ name: "piece", player: 1 }],
+                B: [{ name: "piece-horse", player: 1, opacity: 0.35 }],
+                C: [{ name: "piece", player: 2 }],
+                D: [{ name: "piece-horse", player: 2, opacity: 0.35 }],
+                // threatened pieces
+                E: [{ name: "piece", player: 1 }, { name: "x" }],
+                F: [{ name: "piece-horse", player: 1, opacity: 0.35 }, { name: "x" }],
+                G: [{ name: "piece", player: 2 }, { name: "x" }],
+                H: [{ name: "piece-horse", player: 2, opacity: 0.35 }, { name: "x" }],
+            },
+            pieces: pstr.map(p => p.join("")).join("\n"),
+            key: []
+
+        };
+
+        // Add annotations
+        if (this.stack[this.stack.length - 1]._results.length > 0) {
+            // @ts-ignore
+            rep.annotations = [];
+            for (const move of this.stack[this.stack.length - 1]._results) {
+                if (move.type === "place") {
+                    const [x, y] = this.graph.algebraic2coords(move.where!);
+                    rep.annotations.push({type: "enter", targets: [{row: y, col: x}]});
+                } else if (move.type === "capture") {
+                    const targets: {row: number, col: number}[] = [];
+                    for (const m of move.where!.split(",")) {
+                        const [x, y] = this.graph.algebraic2coords(m);
+                        targets.push({row: y, col: x});
+                    }
+                    // @ts-ignore
+                    rep.annotations.push({type: "exit", targets});
+                }
+            }
+        }
+        return rep;
+    }
+
+    public getPlayerScore(player: playerid): number {
+        return this.scores[player - 1];
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [{ name: i18next.t("apgames:status.SCORES"), scores: [`${this.scores[0]} / ${this.threshold}`, `${this.scores[1]} / ${this.threshold}`] }];
+    }
+
+    public status(): string {
+        let status = super.status();
+
+        if (this.variants !== undefined) {
+            status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Score**:\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.scores[n - 1]} / ${this.threshold}\n\n`;
+        }
+
+        return status;
+    }
+
+    public chat(node: string[], player: string, results: APMoveResult[], r: APMoveResult): boolean {
+        let resolved = false;
+        switch (r.type) {
+            case "place":
+                node.push(i18next.t("apresults:PLACE.blooms", {player, where: r.where, what: r.what}));
+                resolved = true;
+                break;
+            case "capture":
+                node.push(i18next.t("apresults:CAPTURE.blooms", {player, count: r.count, what: r.what}));
+                resolved = true;
+                break;
+        }
+        return resolved;
+    }
+
+    public clone(): BloomsGame {
+        return new BloomsGame(this.serialize());
+    }
+}

--- a/src/games/index.ts
+++ b/src/games/index.ts
@@ -77,6 +77,7 @@ import { MeridiansGame, IMeridiansState } from "./meridians";
 import { ExxitGame, IExxitState } from "./exxit";
 import { MattockGame, IMattockState } from "./mattock";
 import { CatchupGame, ICatchupState } from "./catchup";
+import { BloomsGame, IBloomsState } from "./blooms";
 
 export {
     APGamesInformation, GameBase, GameBaseSimultaneous, IAPGameState,
@@ -156,6 +157,7 @@ export {
     ExxitGame, IExxitState,
     MattockGame, IMattockState,
     CatchupGame, ICatchupState,
+    BloomsGame, IBloomsState,
 };
 
 const games = new Map<string, typeof AmazonsGame | typeof BlamGame | typeof CannonGame |
@@ -183,7 +185,7 @@ const games = new Map<string, typeof AmazonsGame | typeof BlamGame | typeof Cann
                               typeof IqishiqiGame | typeof FurlGame | typeof DiffusionGame |
                               typeof HavannahGame | typeof HexGame | typeof TumbleweedGame |
                               typeof MeridiansGame | typeof ExxitGame | typeof MattockGame |
-                              typeof CatchupGame
+                              typeof CatchupGame | typeof BloomsGame
                 >();
 // Manually add each game to the following array
 [
@@ -197,7 +199,7 @@ const games = new Map<string, typeof AmazonsGame | typeof BlamGame | typeof Cann
     AgereGame, BideGame, MiradorGame, RazzleGame, DagEnNachtGame, HexYGame, MurusGame, BounceGame,
     QuagmireGame, BaoGame, AlmataflGame, SlitherGame, ScaffoldGame, ByteGame, LielowGame, ToguzGame,
     TrikeGame, FnapGame, IqishiqiGame, FurlGame, DiffusionGame, HavannahGame, HexGame,
-    TumbleweedGame, MeridiansGame, ExxitGame, MattockGame, CatchupGame,
+    TumbleweedGame, MeridiansGame, ExxitGame, MattockGame, CatchupGame, BloomsGame,
 ].forEach((g) => {
     if (games.has(g.gameinfo.uid)) {
         throw new Error("Another game with the UID '" + g.gameinfo.uid + "' has already been used. Duplicates are not allowed.");
@@ -361,6 +363,8 @@ export const GameFactory = (game: string, ...args: any[]): GameBase|GameBaseSimu
             return new MattockGame(...args);
         case "catchup":
             return new CatchupGame(...args);
+        case "blooms":
+            return new BloomsGame(...args);
     }
     return;
 }


### PR DESCRIPTION
Adding [Blooms](https://boardgamegeek.com/boardgame/249095/blooms). This implementation is quite unconventional when it comes to the colours and the UX.

Traditionally, Player 1 uses blue and black, and Player 2 uses red and yellow. In order to be consistent with Abstract Play's colour interface, I made the colours correspond with the colours assigned for players 1 and 2, and the second colours are the same colours with an opacity of 0.35. There is also a ring around the pieces to further differentiate it from the normal piece.

In terms of the UX, having a stash makes it very annoying to place pieces, so I opted for the ability to swap the colours if you tapped on the placed piece.

Board sizes 6 (default), 8 and 10 are included here.

For the threshold score, I went with the simple X(n) = 5n, where n is the base of the hexhex, so X(6) = 30, X(8) = 40 and X(10) = 50. We may explore a short game variant with a formula to generate a lower threshold for each size.

An alternative threshold that I'm also considering would be some fraction of the total number of cells. Assuming that the fraction is 0.25, X(6) = 31, X(8) = 54, and X(10) = 82.