### PR TITLE
Try white background to make certain renders hopefully look better in dark mode.

### DIFF
--- a/src/games/blooms.ts
+++ b/src/games/blooms.ts
@@ -570,14 +570,14 @@ export class BloomsGame extends GameBase {
             },
             legend: {
                 A: [{ name: "piece", player: 1 }],
-                B: [{ name: "piece-horse", player: 1, opacity: 0.5 }],
+                B: [{ name: "piece", colour: "#FFF" }, { name: "piece-horse", player: 1, opacity: 0.5 }],
                 C: [{ name: "piece", player: 2 }],
-                D: [{ name: "piece-horse", player: 2, opacity: 0.5 }],
+                D: [{ name: "piece", colour: "#FFF" }, { name: "piece-horse", player: 2, opacity: 0.5 }],
                 // threatened pieces
                 E: [{ name: "piece", player: 1 }, { name: "x" }],
-                F: [{ name: "piece-horse", player: 1, opacity: 0.5 }, { name: "x" }],
+                F: [{ name: "piece", colour: "#FFF" }, { name: "piece-horse", player: 1, opacity: 0.5 }, { name: "x" }],
                 G: [{ name: "piece", player: 2 }, { name: "x" }],
-                H: [{ name: "piece-horse", player: 2, opacity: 0.5 }, { name: "x" }],
+                H: [{ name: "piece", colour: "#FFF" }, { name: "piece-horse", player: 2, opacity: 0.5 }, { name: "x" }],
             },
             pieces: pstr.map(p => p.join("")).join("\n"),
             key: []

--- a/src/games/mattock.ts
+++ b/src/games/mattock.ts
@@ -38,7 +38,7 @@ export class MattockGame extends GameBase {
                 urls: ["https://games.drew-edwards.com/"]
             }
         ],
-        flags: ["multistep", "automove", "scores"],
+        flags: ["multistep", "automove", "scores", "random-start"],
         variants: [
             {
                 uid: "size-5",
@@ -840,6 +840,12 @@ export class MattockGame extends GameBase {
                 break;
         }
         return resolved;
+    }
+
+    public getStartingPosition(): string {
+        // Return the locations of Player 1's miners at start of game.
+        // Player 2's miners are the 180 degree rotation of these.
+        return [...this.stack[0].board.entries()].filter(e => e[1] === 1).map(e => e[0]).sort().join(",");
     }
 
     public clone(): MattockGame {

--- a/src/games/mattock.ts
+++ b/src/games/mattock.ts
@@ -734,7 +734,8 @@ export class MattockGame extends GameBase {
             const [x, y] = this.graph.algebraic2coords(cell);
             points.push({ row: y, col: x });
         }
-        const markers: Array<any> = []
+        const markers: Array<any> = [];
+        markers.push({ type: "flood", colour: "#FFF", opacity: 1.0, points });
         markers.push({ type: "flood", colour: "#444", opacity: 0.6, points });
 
         // Build rep


### PR DESCRIPTION
I'm trying a #FFF background at 1.0 opacity to see if it improves the visibility of the board in dark mode for Mattock and Blooms.

Also added the "random-start" flag for Mattock.