### PR TITLE
Catchup: Fixed sorting for larger boards

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -1415,6 +1415,12 @@
                 "name": "Hide threatened"
             }
         },
+        "trike": {
+            "hide-moves": {
+                "description": "Don't show possible moves.",
+                "name": "Hide moves"
+            }
+        },
         "tumbleweed": {
             "hide-influence": {
                 "description": "Don't show line of sight.",

--- a/src/games/catchup.ts
+++ b/src/games/catchup.ts
@@ -139,6 +139,17 @@ export class CatchupGame extends GameBase {
         return this;
     }
 
+    private sort(a: string, b: string): number {
+        // Sort two cells. This is necessary because "a10" should come after "a9".
+        const [ax, ay] = this.graph.algebraic2coords(a);
+        const [bx, by] = this.graph.algebraic2coords(b);
+        if (ay < by) { return 1; }
+        if (ay > by) { return -1; }
+        if (ax < bx) { return -1; }
+        if (ax > bx) { return 1; }
+        return 0;
+    }
+
     public moves(player?: playerid, permissive = false): string[] {
         if (this.gameover) { return []; }
         if (player === undefined) {
@@ -146,7 +157,7 @@ export class CatchupGame extends GameBase {
         }
 
         const moves: string[] = [];
-        const empties = (this.graph.listCells() as string[]).filter(c => ! this.board.has(c)).sort();
+        const empties = (this.graph.listCells() as string[]).filter(c => ! this.board.has(c)).sort((a, b) => this.sort(a, b));
         const maxMoves = this.maxMoves(player);
         // Get singles
         for (const cell of empties) {
@@ -240,9 +251,9 @@ export class CatchupGame extends GameBase {
             } else {
                 const moves = move.split(",");
                 if (moves.includes(cell)) {
-                    newmove = moves.filter(m => m !== cell).sort().join(",");
+                    newmove = moves.filter(m => m !== cell).sort((a, b) => this.sort(a, b)).join(",");
                 } else {
-                    newmove = [...moves, cell].sort().join(",");
+                    newmove = [...moves, cell].sort((a, b) => this.sort(a, b)).join(",");
                 }
             }
             const result = this.validateMove(newmove) as IClickResult;
@@ -279,8 +290,8 @@ export class CatchupGame extends GameBase {
         move1 = move1.replace(/\s+/g, "");
         move2 = move2.toLowerCase();
         move2 = move2.replace(/\s+/g, "");
-        const moves1 = move1.split(",").sort();
-        const moves2 = move2.split(",").sort();
+        const moves1 = move1.split(",").sort((a, b) => this.sort(a, b));
+        const moves2 = move2.split(",").sort((a, b) => this.sort(a, b));
         if (moves1.length !== moves2.length) { return false; }
         for (let i = 0; i < moves1.length; i++) {
             if (moves1[i] !== moves2[i]) { return false; }
@@ -369,7 +380,7 @@ export class CatchupGame extends GameBase {
 
         m = m.toLowerCase();
         m = m.replace(/\s+/g, "");
-        m = m.split(",").sort().join(",")
+        m = m.split(",").sort((a, b) => this.sort(a, b)).join(",")
         const moves = m.split(",");
 
         if (!trusted) {

--- a/src/games/mattock.ts
+++ b/src/games/mattock.ts
@@ -735,7 +735,6 @@ export class MattockGame extends GameBase {
             points.push({ row: y, col: x });
         }
         const markers: Array<any> = [];
-        markers.push({ type: "flood", colour: "#FFF", opacity: 1.0, points });
         markers.push({ type: "flood", colour: "#444", opacity: 0.6, points });
 
         // Build rep

--- a/src/games/trike.ts
+++ b/src/games/trike.ts
@@ -46,7 +46,8 @@ export class TrikeGame extends GameBase {
             {uid: "standard-13", group: "board"},
             {uid: "standard-15", group: "board"},
         ],
-        flags: ["pie", "automove"]
+        flags: ["pie", "automove"],
+        displays: [{uid: "hide-moves"}],
     };
     public numplayers = 2;
     public currplayer!: playerid;
@@ -425,7 +426,17 @@ export class TrikeGame extends GameBase {
         };
     }
 
-    public render(): APRenderRep {
+    public render(opts?: { altDisplay: string | undefined }): APRenderRep {
+        let altDisplay: string | undefined;
+        if (opts !== undefined) {
+            altDisplay = opts.altDisplay;
+        }
+        let showMoves = true;
+        if (altDisplay !== undefined) {
+            if (altDisplay === "hide-moves") {
+                showMoves = false;
+            }
+        }
         // Build piece string
         const pieces: string[][] = [];
         const lastPosition = this.getLastPosition();
@@ -494,7 +505,7 @@ export class TrikeGame extends GameBase {
                     rep.annotations.push({type: "move", targets: [{row: fx, col: fy},{row: tx, col: ty}]});
                 }
             }
-            if (this.lastmove !== undefined) {
+            if (showMoves && this.lastmove !== undefined) {
                 for (const cell of this.moves()) {
                     const [x, y] = this.algebraic2coords(cell);
                     rep.annotations.push({type: "dots", targets: [{row: x, col: y}]});


### PR DESCRIPTION
Sort moves based on coordinates so that "a10" comes after "a9", which is necessary on boards larger than hexhex-5. I still have no idea why the performance on the live server for hexhex-6 is so bad when every move is instantaneous on the local playground.

While I'm at it, I also added the option to remove possible move indicators for Trike without disabling last move indicators completely.

Also removed the white background for flood fill in Mattock that I added in the previous PR because it covers the hex outlines.