### PR TITLE
Add current move highlight using yellow flood fill.

### DIFF
--- a/src/games/blooms.ts
+++ b/src/games/blooms.ts
@@ -68,6 +68,7 @@ export class BloomsGame extends GameBase {
     private threshold = 0;
     private boardSize = 0;
     private captured: Set<string>[] = [];
+    private currMoveHighlight: string[] = [];
 
     constructor(state?: IBloomsState | string, variants?: string[]) {
         super();
@@ -411,9 +412,11 @@ export class BloomsGame extends GameBase {
             const [tile, cell] = this.splitTileCell(move);
             this.board.set(cell, [this.currplayer, tile]);
             this.results.push({type: "place", where: cell, what: tile === 1 ? tileNames[0] : tileNames[1]});
+            this.currMoveHighlight.push(cell);
         }
         this.captured = this.toCapture(this.currplayer % 2 + 1 as playerid);
         if (partial) { return this; }
+        this.currMoveHighlight = [];
         const threatenedGroups = this.captured;
         for (const group of threatenedGroups) {
             // get tile of arbitrary member
@@ -583,12 +586,21 @@ export class BloomsGame extends GameBase {
             pstr.push(pieces);
         }
 
+        const points: { row: number, col: number }[] = [];
+        for (const cell of this.currMoveHighlight) {
+            const [x, y] = this.graph.algebraic2coords(cell);
+            points.push({ row: y, col: x });
+        }
+        let markers: Array<any> | undefined = points.length !== 0 ? [{ type: "flood", colour: "#FFFF00", opacity: 0.4, points }] : undefined;
+
         // Build rep
         const rep: APRenderRep =  {
             board: {
                 style: "hex-of-hex",
                 minWidth: this.boardSize,
                 maxWidth: (this.boardSize * 2) - 1,
+                // @ts-ignore
+                markers,
             },
             legend: {
                 A: [{ name: "piece", player: 1 }],

--- a/src/games/catchup.ts
+++ b/src/games/catchup.ts
@@ -64,6 +64,7 @@ export class CatchupGame extends GameBase {
     public sizes: number[][] = [[], []];
     public lastMaxs: [number, number] = [0, 0];
     private boardSize = 0;
+    private currMoveHighlight: string[] = [];
 
     constructor(state?: ICatchupState | string, variants?: string[]) {
         super();
@@ -405,6 +406,7 @@ export class CatchupGame extends GameBase {
         for (const move of moves) {
             this.board.set(move, this.currplayer);
             this.results.push({type: "place", where: move});
+            this.currMoveHighlight.push(move);
         }
 
         this.lastmove = m;
@@ -413,6 +415,7 @@ export class CatchupGame extends GameBase {
 
         if (partial) { return this; }
 
+        this.currMoveHighlight = [];
         this.currplayer = this.currplayer % 2 + 1 as playerid;
         this.checkEOG();
         this.saveState();
@@ -505,12 +508,21 @@ export class CatchupGame extends GameBase {
             pstr.push(pieces);
         }
 
+        const points: { row: number, col: number }[] = [];
+        for (const cell of this.currMoveHighlight) {
+            const [x, y] = this.graph.algebraic2coords(cell);
+            points.push({ row: y, col: x });
+        }
+        let markers: Array<any> | undefined = points.length !== 0 ? [{ type: "flood", colour: "#FFFF00", opacity: 0.4, points }] : undefined;
+
         // Build rep
         const rep: APRenderRep =  {
             board: {
                 style: "hex-of-hex",
                 minWidth: this.boardSize,
                 maxWidth: (this.boardSize * 2) - 1,
+                // @ts-ignore
+                markers,
             },
             legend: {
                 A: {


### PR DESCRIPTION
For multi-placement games, it feels like it's easy to lose track of what stones have been placed. In the implementations of these games, clicking on placed-but-not-submitted stones potentially do something (remove stones in Catchup, and swap colours in Blooms). I'm attempting a yellow flood fill to hopefully make it easier to keep track of the current move.