### PR TITLE
Adding some variantGroups descriptions, and Hex size-19

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -1038,6 +1038,16 @@
         }
     },
     "variantGroups": {
+        "blooms": {
+            "board": {
+                "name": "Default board (base 6)"
+            }
+        },
+        "catchup": {
+            "board": {
+                "name": "Default board (base 5)"
+            }
+        },
         "exxit": {
             "length": {
                 "name": "game length (39 tiles)"
@@ -1046,10 +1056,48 @@
                 "description": "Starts with a \"cross\" of two tiles of each colour."
             }
         },
+        "havannah": {
+            "board": {
+                "name": "Size 8 board.",
+                "description": "Competitive board."
+            }
+        },
+        "hex": {
+            "board": {
+                "name": "Size 13 board.",
+                "description": "Competitive board"
+            }
+        },
+        "mattock": {
+            "board": {
+                "name": "Default board (base-7)"
+            }
+        },
+        "meridians": {
+            "size-6": {
+                "name": "Default board (base 7)"
+            }
+        },
+        "slither": {
+            "board": {
+                "name": "9x9 board"
+            }
+        },
+        "trike": {
+            "board": {
+                "name": "Triangle (11 wide)",
+                "description": "Casual board."
+            }
+        },
+        "tumbleweed": {
+            "board": {
+                "name": "Competitive board (8 cells)"
+            }
+        },
         "veletas": {
             "board": {
                 "name": "10x10 board",
-                "description": "Default board with 7 neutral pieces"
+                "description": "Default board with 7 neutral pieces."
             }
         }
     },
@@ -1226,25 +1274,25 @@
         "havannah": {
             "size-4": {
                 "name": "Size 4 board.",
-                "description": "Tiny board"
+                "description": "Tiny board."
             },
             "size-6": {
                 "name": "Size 6 board.",
-                "description": "Smaller board"
+                "description": "Smaller board."
             },
             "size-10": {
                 "name": "Size 10 board.",
-                "description": "Larger board"
+                "description": "Larger board."
             }
         },
         "hex": {
             "size-11": {
                 "name": "Size 11 board.",
-                "description": "Smaller board"
+                "description": "Smaller board."
             },
             "size-15": {
                 "name": "Size 15 board.",
-                "description": "Larger board"
+                "description": "Larger board."
             }
         },
         "hexy": {
@@ -1418,15 +1466,15 @@
         "trike": {
             "standard-7": {
                 "name": "Triangle (7 wide)",
-                "description": "Learning board"
+                "description": "Learning board."
             },
             "standard-13": {
                 "name": "Triangle (13 wide)",
-                "description": "Competitive board"
+                "description": "Competitive board."
             },
             "standard-15": {
                 "name": "Triangle (15 wide)",
-                "description": "Large board"
+                "description": "Large board."
             }
         },
         "tumbleweed": {

--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -1040,12 +1040,12 @@
     "variantGroups": {
         "blooms": {
             "board": {
-                "name": "Default board (base 6)"
+                "name": "board (base 6)"
             }
         },
         "catchup": {
             "board": {
-                "name": "Default board (base 5)"
+                "name": "board (base 5)"
             }
         },
         "exxit": {
@@ -1070,12 +1070,12 @@
         },
         "mattock": {
             "board": {
-                "name": "Default board (base-7)"
+                "name": "board (base-7)"
             }
         },
         "meridians": {
             "size-6": {
-                "name": "Default board (base 7)"
+                "name": "board (base 7)"
             }
         },
         "slither": {

--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -1293,6 +1293,10 @@
             "size-15": {
                 "name": "Size 15 board.",
                 "description": "Larger board."
+            },
+            "size-19": {
+                "name": "Size 19 board.",
+                "description": "Much larger board."
             }
         },
         "hexy": {

--- a/src/games/blooms.ts
+++ b/src/games/blooms.ts
@@ -593,7 +593,7 @@ export class BloomsGame extends GameBase {
             const [x, y] = this.graph.algebraic2coords(cell);
             points.push({ row: y, col: x });
         }
-        const markers: Array<any> | undefined = points.length !== 0 ? [{ type: "flood", colour: "#FFFF00", opacity: 0.4, points }] : undefined;
+        const markers: Array<any> | undefined = points.length !== 0 ? [{ type: "flood", colour: "#FFFF00", opacity: 0.25, points }] : undefined;
 
         // Build rep
         const rep: APRenderRep =  {

--- a/src/games/catchup.ts
+++ b/src/games/catchup.ts
@@ -513,7 +513,7 @@ export class CatchupGame extends GameBase {
             const [x, y] = this.graph.algebraic2coords(cell);
             points.push({ row: y, col: x });
         }
-        const markers: Array<any> | undefined = points.length !== 0 ? [{ type: "flood", colour: "#FFFF00", opacity: 0.4, points }] : undefined;
+        const markers: Array<any> | undefined = points.length !== 0 ? [{ type: "flood", colour: "#FFFF00", opacity: 0.25, points }] : undefined;
 
         // Build rep
         const rep: APRenderRep =  {

--- a/src/games/hex.ts
+++ b/src/games/hex.ts
@@ -55,6 +55,10 @@ export class HexGame extends GameBase {
                 uid: "size-15",
                 group: "board",
             },
+            {
+                uid: "size-19",
+                group: "board",
+            },
         ]
     };
 


### PR DESCRIPTION
Adding the variantGroups description for default board sizes for the games that I know.

Adjusted the marker opacity of Catchup and Blooms.

I think Hex is surprisingly popular. Size-19 seems to be of interest to the community, so let's add it.