### PR TITLE
Onager: Add deepclone

### DIFF
--- a/src/games/onager.ts
+++ b/src/games/onager.ts
@@ -7,6 +7,8 @@ import { APMoveResult } from "../schemas/moveresults";
 import { reviver, UserFacingError } from "../common";
 import i18next from "i18next";
 import { HexTriGraph } from "../common/graphs";
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const deepclone = require("rfdc/default");
 
 export type playerid = 1|2|3;  // Player 3 is used for the neutral obstacle pieces.
 type directions = "NE"|"E"|"SE"|"SW"|"W"|"NW"
@@ -125,7 +127,7 @@ export class OnagerGame extends GameBase {
 
         const state = this.stack[idx];
         this.currplayer = state.currplayer;
-        this.board = new Map(state.board);
+        this.board = deepclone(state.board) as Map<string, playerid[]>;
         this.lastmove = state.lastmove;
         this.results = [...state._results];
         this.boardSize = this.getBoardSize();
@@ -542,7 +544,7 @@ export class OnagerGame extends GameBase {
             _timestamp: new Date(),
             currplayer: this.currplayer,
             lastmove: this.lastmove,
-            board: new Map(this.board),
+            board: deepclone(this.board) as Map<string, playerid[]>,
         };
     }
 


### PR DESCRIPTION
As per discussion on Discord, I'm readding the deepclones just for safe measure. I don't think it's necessary, but one of the game records on the dev server was lost on game end during testing for some reason, and these stacks that are shared across moves were suspect. There is minimal overhead anyway, so until the root cause is found, we can leave this here. Hopefully we won't run into any issues.