### PR TITLE
Proposal: Use `Number` instead of `parseInt`.

### DIFF
--- a/src/common/graphs/hex-slanted.ts
+++ b/src/common/graphs/hex-slanted.ts
@@ -29,8 +29,8 @@ export class HexSlantedGraph implements IGraph {
         if (x === undefined || x < 0) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if (y === undefined || isNaN(y)) {
+        const y = Number(num);
+        if (y === undefined || isNaN(y) || num === "") {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, y - 1];

--- a/src/common/graphs/hextri.ts
+++ b/src/common/graphs/hextri.ts
@@ -31,8 +31,8 @@ export class HexTriGraph implements IGraph {
     public algebraic2coords(cell: string): [number, number] {
         const pair: string[] = cell.split("");
         const num = (pair.slice(1)).join("");
-        const x = parseInt(num, 10);
-        if ( (x === undefined) || (isNaN(x)) ) {
+        const x = Number(num);
+        if ( (x === undefined) || (isNaN(x)) || num === "" ) {
             throw new Error(`The column label is invalid: ${num}`);
         }
         const y = columnLabels.indexOf(pair[0]);

--- a/src/common/graphs/snubsquare.ts
+++ b/src/common/graphs/snubsquare.ts
@@ -26,8 +26,8 @@ export class SnubSquareGraph implements IGraph {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, this.height - y];

--- a/src/common/graphs/sowing-no-ends.ts
+++ b/src/common/graphs/sowing-no-ends.ts
@@ -32,8 +32,8 @@ export class SowingNoEndsGraph implements IGraph {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, this.height - y];

--- a/src/common/graphs/square-diag.ts
+++ b/src/common/graphs/square-diag.ts
@@ -26,8 +26,8 @@ export class SquareDiagGraph implements IGraph {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, this.height - y];

--- a/src/common/graphs/square-fanorona.ts
+++ b/src/common/graphs/square-fanorona.ts
@@ -26,8 +26,8 @@ export class SquareFanoronaGraph implements IGraph {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, this.height - y];

--- a/src/common/graphs/square-orth.ts
+++ b/src/common/graphs/square-orth.ts
@@ -28,8 +28,8 @@ export class SquareOrthGraph implements IGraph {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, this.height - y];

--- a/src/common/graphs/square.ts
+++ b/src/common/graphs/square.ts
@@ -26,8 +26,8 @@ export class SquareGraph implements IGraph {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, this.height - y];

--- a/src/games/_base.ts
+++ b/src/games/_base.ts
@@ -203,8 +203,8 @@ export abstract class GameBase  {
         if ( (x === undefined) || (x < 0) ) {
             throw new Error(`The column label is invalid: ${pair[0]}`);
         }
-        const y = parseInt(num, 10);
-        if ( (y === undefined) || (isNaN(y)) ) {
+        const y = Number(num);
+        if ( (y === undefined) || (isNaN(y)) || num === "" ) {
             throw new Error(`The row label is invalid: ${pair[1]}`);
         }
         return [x, height - y];


### PR DESCRIPTION
In the `algebraic2coords` methods, we are using `parseInt(num, 10)`. This looks for the first number, so if `num === "2,a6,b4"`, it gets parsed such that `y === 2`. Since a lot of our validation involves a try catch block to see if the `algebraic2coords` returns an error, the result is a lot of false negatives in the validation. If we used `Number` instead, I believe it returns NaN when it's not purely a number, meaning the validation becomes slightly more robust without any additional checks aside from if `num === ""` (as `Number("") === 0`). But since `Number` is more efficient than `parseInt`, it will likely be a net performance improvement anyway (unbenchmarked claim). Another caveat is that nulls and undefined values will also return 0 when `parseInt` returns NaN, but I did not check for them.

Note that I'm aware that the `algebraic2coords` and `coords2algebraic` methods are not intended to be surjective, and it doesn't check if the returned cell is indeed on the board given a board size, for example. I just think that this is kind of "free", so we might as well do it this way to reduce unexpected behaviour.

I cannot be sure if this wouldn't break any thing though, because there could potentially be games that intentionally exploit this particular `parseInt` property.