### PR TITLE
Cannon & Tumbleweed: Remove opacity for threatened piece highlight

### DIFF
--- a/src/games/cannon.ts
+++ b/src/games/cannon.ts
@@ -951,22 +951,22 @@ export class CannonGame extends GameBase {
                 ],
                 // Threatened pieces
                 C: [
-                    { name: "piece-borderless", scale: 1.1, player: 2, opacity: 0.7 },
+                    { name: "piece-borderless", scale: 1.1, player: 2 },
                     { name: "piece", player: 1 },
                     { name: "cannon-piece", scale: 0.5 }
                 ],
                 D: [
-                    { name: "piece-square-borderless", scale: 1.1, player: 2, opacity: 0.7 },
+                    { name: "piece-square-borderless", scale: 1.1, player: 2 },
                     { name: "piece-square", player: 1 },
                     { name: "cannon-town", scale: 0.75 }
                 ],
                 W: [
-                    { name: "piece-borderless", scale: 1.1, player: 1, opacity: 0.7 },
+                    { name: "piece-borderless", scale: 1.1, player: 1 },
                     { name: "piece", player: 2 },
                     { name: "cannon-piece", scale: 0.5, rotate: 180 }
                 ],
                 X: [
-                    { name: "piece-square-borderless", scale: 1.1, player: 1, opacity: 0.7 },
+                    { name: "piece-square-borderless", scale: 1.1, player: 1 },
                     { name: "piece-square", player: 2 },
                     { name: "cannon-town", scale: 0.75, rotate: 180 }
                 ],

--- a/src/games/tumbleweed.ts
+++ b/src/games/tumbleweed.ts
@@ -578,20 +578,20 @@ export class TumbleweedGame extends GameBase {
                 ]
             } else if (piece === "F") {
                 legend[name] = [
-                    { name: "piece-borderless", scale: 1.1, player: 1, opacity: 0.7 },
+                    { name: "piece-borderless", scale: 1.1, player: 1 },
                     { name: "piece", player },
                     { text: sizeStr, colour: "#000", scale: 0.75 },
                 ]
             } else if (piece === "G") {
                 legend[name] = [
-                    { name: "piece-borderless", scale: 1.1, player: 2, opacity: 0.7 },
+                    { name: "piece-borderless", scale: 1.1, player: 2 },
                     { name: "piece", player },
                     { text: sizeStr, colour: "#000", scale: 0.75 },
                 ]
             } else /* if (piece === "H") */ {
                 legend[name] = [
-                    { name: "piece-borderless", scale: 1.1, player: 1, opacity: 0.7 },
-                    { name: "piece-borderless", scale: 1.1, player: 2, opacity: 0.7 },
+                    { name: "piece-borderless", scale: 1.1, player: 1 },
+                    { name: "piece-borderless", scale: 1.1, player: 2 },
                     { name: "piece", player },
                     { text: sizeStr, colour: "#000", scale: 0.75 },
                 ]


### PR DESCRIPTION
The 0.7 opacity is unnecessary and it makes it hard to see for lighter colours. I left out that parameter for Tumbleweed by accident, so that's probably why nobody complained before.