### PR TITLE
ConHex: Fix error in west line.

### DIFF
--- a/src/games/conhex.ts
+++ b/src/games/conhex.ts
@@ -165,7 +165,7 @@ export class ConhexGame extends GameBase {
         const lineW: string[] = [];
         for (let y = 0; y < rowCount; y++) {
             const E = this.coords2space(rowCount - 1 + y, 0);
-            const W = this.coords2space(3 * (rowCount - 1) + y, 0);
+            const W = this.coords2space(y === rowCount - 1 ? 0 : 3 * (rowCount - 1) + y, 0);
             lineE.push(E);
             lineW.push(W);
         }


### PR DESCRIPTION
Fixed a bug where the (1,1) space was not part of the west boundary of the horizontal player.