### PR TITLE
Catchup: Try using hex-pointy instead of piece

### DIFF
--- a/src/games/catchup.ts
+++ b/src/games/catchup.ts
@@ -526,11 +526,13 @@ export class CatchupGame extends GameBase {
             },
             legend: {
                 A: {
-                    name: "piece",
+                    name: "hex-pointy",
+                    scale: 1.35,
                     player: 1
                 },
                 B: {
-                    name: "piece",
+                    name: "hex-pointy",
+                    scale: 1.35,
                     player: 2
                 },
             },


### PR DESCRIPTION
There was a request to fill the space in Catchup instead of to put a piece. I'm trying a hex-pointy that is scaled to 1.35.