### PR TITLE
Hnefatafl: some changes

### DIFF
--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -1103,7 +1103,7 @@ export class TaflGame extends GameBase {
                 if (this.isOnEdge(n)) { return false; }
                 if (this.board.has(n)) {
                     const [pl,] = this.board.get(n)!
-                    if (pl === 1) { continue; }
+                    if (pl === this.playerAttacker) { continue; }
                     defenders.add(n);
                 }
                 todo.push(n);

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -44,7 +44,7 @@ const defaultVariant = "historical-9x9-tcross-w";
 
 export class TaflGame extends GameBase {
     public static readonly gameinfo: APGamesInformation = {
-        name: "Tafl",
+        name: "Hnefatafl",
         uid: "tafl",
         playercounts: [2],
         version: "20240208",

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -1157,7 +1157,7 @@ export class TaflGame extends GameBase {
                 }
             }
             // if there is an encirclement, then the defender is in check.
-            if (this.settings.ruleset.enclosureWin! && this.encircled()) {
+            if (this.settings.ruleset.encirclementWin! && this.encircled()) {
                 return [this.playerDefender];
             }
         } else {
@@ -1197,7 +1197,7 @@ export class TaflGame extends GameBase {
         } else if (this.settings.ruleset.repetition === "draw" && this.stateCount() >= 2) {
             this.gameover = true;
             this.winner = [1, 2];
-        } else if (this.currplayer === this.playerAttacker && this.settings.ruleset.enclosureWin! && this.encircled()) {
+        } else if (this.currplayer === this.playerAttacker && this.settings.ruleset.encirclementWin! && this.encircled()) {
             this.gameover = true;
             this.winner = [this.playerAttacker];
         } else if (this.currplayer === this.playerDefender && this.settings.ruleset.hasExitForts! && this.hasExitFort()) {

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -14,17 +14,6 @@ type pieceid = "T" | "K" | "C" | "N";
 const allPieces: pieceid[] = ["T", "K", "C", "N"];
 const orthDirections: Directions[] = ["N", "E", "S", "W"];
 
-const fortNextDirections: Map<Directions, Directions[]> = new Map([
-    ["N", ["W", "N", "E", "NW", "NE"]],
-    ["E", ["N", "E", "S", "NE", "SE"]],
-    ["S", ["E", "S", "W", "SE", "SW"]],
-    ["W", ["S", "W", "N", "SW", "NW"]],
-    ["NE", ["N", "E", "NE"]],
-    ["SE", ["E", "S", "SE"]],
-    ["SW", ["S", "W", "SW"]],
-    ["NW", ["W", "N", "NW"]],
-])  // Next directions to check.
-
 type CellContents = [playerid, pieceid];
 
 interface IMoveState extends IIndividualState {
@@ -1123,7 +1112,6 @@ export class TaflGame extends GameBase {
         // 2. King is on the edge.
         // 3. King has at least one space to move.
         // 4. King is trapped in a space with its own taflmen only.
-        // 5. King has impenetrable fort around it.
         if (kingCell === undefined) {
             const kingCells = Array.from(this.board.entries()).filter(([, [p, pc]]) => p === this.playerDefender && pc === "K").map(([c,]) => c);
             // 1. King is present.
@@ -1156,54 +1144,41 @@ export class TaflGame extends GameBase {
             }
             if (kingHasSpace === undefined) { kingHasSpace = false; }
         }
-        // 5. King has impenetrable fort around it.
-        // Get all non-consecutive pieces that are on the edge both sides of the king.
-        // Then check that there is a way to connect the pieces on one side a piece on
-        // the other side via a path of pieces in such a way that no piece can be captured.
-        // This effectively means that it there are no consecutive diagonal pieces on the path.
-        const edgeDir = this.getEdgeDir(kingCell);
-        const dirsToCheck: Directions[] = edgeDir === "N" || edgeDir === "S" ? ["E", "W"] : ["N", "S"];
-        const fromsTos: string[][] = [];
-        for (const dir of dirsToCheck) {
-            const cells: string[] = [];
-            const ray = this.grid.ray(...this.algebraic2coords(kingCell), dir).map((c) => this.coords2algebraic(...c));
-            let consecutiveFlag = false;
-            for (const cell of ray) {
-                if (this.board.has(cell)) {
-                    const [pl,] = this.board.get(cell)!;
-                    if (pl === this.playerDefender) {
-                        if (!consecutiveFlag) {
-                            cells.push(cell);
-                            consecutiveFlag = true;
-                        }
-                        continue;
-                    }
-                    break;
-                }
-                consecutiveFlag = false;
-            }
-            fromsTos.push(cells);
-        }
-        const [froms, tos] = fromsTos;
-        for (const from of froms) {
-            if (this.fromToConnected(from, edgeDir, tos, [from])) { return true; }
-        }
-        return false;
+        return true;
     }
 
-    private fromToConnected(curr: string, direction: Directions, tos: string[], path: string[]): boolean {
-        // Traverse to check if `from` is connected to any of the tos.
-        if (tos.includes(curr)) { return true; }
-        for (const next of fortNextDirections.get(direction)!) {
-            const nextCell = this.coords2algebraic(...RectGrid.move(...this.algebraic2coords(curr), next));
-            if (!this.board.has(nextCell)) { continue; }
-            const [pl, pc] = this.board.get(nextCell)!;
-            if (pl !== this.playerDefender || pc === "K") { continue; }
-            if (this.fromToConnected(nextCell, next, tos, [...path, nextCell])) {
-                return true;
+    public inCheck(): number[] {
+        // Only detects check for the current player
+        if (this.currplayer === this.playerDefender) {
+            // if the attacker can capture the king, then the defender is in check.
+            for (const move of this.moves(this.playerAttacker)) {
+                if (this.kingDead(this.extractCaptures(move))) {
+                    return [this.playerDefender];
+                }
+            }
+            // if there is an encirclement, then the defender is in check.
+            if (this.settings.ruleset.enclosureWin! && this.encircled()) {
+                return [this.playerDefender];
+            }
+        } else {
+            // if the defender can escape the next turn, then the attacker is in check.
+            const kingPos = Array.from(this.board.entries()).filter(([, [p, pc]]) => p === this.playerDefender && pc === "K").map(([c,]) => c);
+            if (kingPos.length > 0) {
+                for (const move of this.getAllMoves(kingPos[0])) {
+                    const moveSegments = move.split(" ");
+                    const breakups = moveSegments[moveSegments.length - 1].split(/[-\^x]/);
+                    const to = breakups[1];
+                    if (this.escaped(to)) {
+                        return [this.playerAttacker];
+                    }
+                }
+            }
+            // if there is an escape fort, then the attacker is in check.
+            if (this.settings.ruleset.hasExitForts! && this.hasExitFort()) {
+                return [this.playerAttacker];
             }
         }
-        return false;
+        return [];
     }
 
     protected checkEOG(): TaflGame {
@@ -1222,10 +1197,10 @@ export class TaflGame extends GameBase {
         } else if (this.settings.ruleset.repetition === "draw" && this.stateCount() >= 2) {
             this.gameover = true;
             this.winner = [1, 2];
-        } else if (this.settings.ruleset.enclosureWin! && this.encircled()) {
+        } else if (this.currplayer === this.playerAttacker && this.settings.ruleset.enclosureWin! && this.encircled()) {
             this.gameover = true;
             this.winner = [this.playerAttacker];
-        } else if (this.settings.ruleset.hasExitForts! && this.hasExitFort()) {
+        } else if (this.currplayer === this.playerDefender && this.settings.ruleset.hasExitForts! && this.hasExitFort()) {
             this.gameover = true;
             this.winner = [this.playerDefender];
         } else if (!this.hasMoves()) {

--- a/src/games/tafl/ruleset.d.ts
+++ b/src/games/tafl/ruleset.d.ts
@@ -204,9 +204,9 @@ export interface Ruleset {
    */
   hasExitForts?: boolean;
   /**
-   * Whether the game has an enclosure win condition
+   * Whether the game has an encirclement win condition
    */
-  enclosureWin?: boolean;
+  encirclementWin?: boolean;
   /**
    * What happens in the event of a repetition
    */

--- a/src/games/tafl/ruleset.json
+++ b/src/games/tafl/ruleset.json
@@ -247,8 +247,8 @@
             "type": "boolean",
             "default": false
         },
-        "enclosureWin": {
-            "description": "Whether the game has an enclosure win condition",
+        "encirclementWin": {
+            "description": "Whether the game has an encirclement win condition",
             "type": "boolean",
             "default": true
         },

--- a/src/games/tafl/settings.ts
+++ b/src/games/tafl/settings.ts
@@ -92,7 +92,7 @@ export class TaflSettings {
                     throne: { emptyAnvilTo: "all-piercing"},
                     corner: { type: "corner", anvilTo: "men-only-piercing" },
                     berserkCapture: true,
-                    enclosureWin: false,
+                    encirclementWin: false,
                 });
                 break;
             case "tyr":
@@ -106,7 +106,7 @@ export class TaflSettings {
                     pieces: { king: { strength: "weak", berserkEscape: true }, knight: { jump: "jump-taflmen" } },
                     throne: { type: "no-throne" },
                     berserkCapture: true,
-                    enclosureWin: false,
+                    encirclementWin: false,
                 });
                 break;
             case "magpie":
@@ -329,7 +329,7 @@ export class TaflSettings {
         ruleset.hasExitForts ??= false;
         ruleset.berserkCapture ??= false;
         ruleset.repetition ??= "defenders-lose";
-        ruleset.enclosureWin ??= true;
+        ruleset.encirclementWin ??= true;
         return ruleset;
     }
 }


### PR DESCRIPTION
- Renamed Tafl to Hnefatafl
- Simplified escape fort rule so that it no longer checks if the fort is unbreakable. This is because I wanted it to be consistent with the encirclement rule, and it's slightly more complicated to check if encirclement is unbreakable because I need to care about what's on the "inside" vs "outside" the encirclement.
- The win for encirclement and escape fort is checked after the mover's turn, so the opponent gets one chance to break the encirclement/fort before the game ends.
- Added `inCheck` because it's part of the traditional rules, but checkmate is not enforced. The King still has to make the escape or be captured.