### PR TITLE
Hnefatafl: Rename historical to linnaean.

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -116,7 +116,7 @@
         "queensland": "After the first game completes, the board resets and you play a second game but with blue playing first. Highest combined score wins.",
         "razzle": "The implementation here is the so called tournament rules.",
         "tablero": "When it's your turn, you will see the dice you have to work with, but once your move is complete, the dice will reroll. Exploration is not helpful because the dice roll is not finalized until after the move is submitted. As you scroll back through the game history, the dice you see are the dice for the *next* turn. The dice used to make the move you're seeing are displayed below the board.\n\nWhile most moves can be unambiguously made by simple clicks, sometimes a button is more helpful. The Place, Take, and Bump buttons to the left of the board are there if you need them.",
-        "tafl": "The variant names are in the format {ruleset}-{board size}-{initial layout}-{optional: starting player}. For example, 'historical-9x9-tcross-w' is the historical rules on a 9x9 board with T-cross setup, and the starting player is the defenders. If starting player is not mentioned, then attackers start.",
+        "tafl": "The variant names are in the format {ruleset}-{board size}-{initial layout}-{optional: starting player}. For example, 'linnaean-9x9-tcross-w' is the linnaean rules on a 9x9 board with T-cross setup, and the starting player is the defenders. If starting player is not mentioned, then attackers start.",
         "taiji": "Moves are done with two clicks. The first tile you place is always the light one, and then the dark one.",
         "tbt": "When it's your turn, you will see the die you have to work with, but once your move is complete, the die will reroll. Exploration is not helpful because the die roll is not finalized until after the move is submitted. As you scroll back through the game history, the die you see is for the *next* turn. The die used to make the move you're seeing is displayed below the board.",
         "toguz": "Depicting state changes in sowing games is challenging. The initial chosen pit is marked, as is any capture. Small numbers appear to show the change in the number of stones in each pit. If you believe you have encountered a bug, please let us know in Discord.",
@@ -1332,8 +1332,8 @@
         },
         "tafl": {
             "variant": {
-                "name": "historical-9x9-tcross-w",
-                "description": "Historical Saami Tablut based on recent reconstruction of Linnaeus' diary."
+                "name": "linnaean-9x9-tcross-w",
+                "description": "Linnaean Sámi Tablut with historical rules based on recent reconstruction from Linnaeus' diary."
             }
         },
         "take": {
@@ -1804,13 +1804,13 @@
             }
         },
         "tafl": {
-            "historical-11x11-belldiamond-w": {
-                "name": "historical-11x11-belldiamond-w",
-                "description": "Bell-diamond setup with rules based on a recent reconstruction of Linnaeus' diary."
+            "linnaean-11x11-belldiamond-w": {
+                "name": "linnaean-11x11-belldiamond-w",
+                "description": "Bell-diamond setup with historical rules based on a recent reconstruction from Linnaeus' diary."
             },
-            "historical-11x11-lewiscross-w": {
-                "name": "historical-11x11-lewiscross-w",
-                "description": "Lewis-cross setup with rules based on a recent reconstruction of Linnaeus' diary."
+            "linnaean-11x11-lewiscross-w": {
+                "name": "linnaean-11x11-lewiscross-w",
+                "description": "Lewis-cross setup with historical rules based on a recent reconstruction from Linnaeus' diary."
             },
             "copenhagen-11x11-tdiamond": {
                 "name": "copenhagen-11x11-tdiamond",
@@ -1818,15 +1818,15 @@
             },
             "berserk-11x11-tdiamondberserk": {
                 "name": "berserk-11x11-tdiamondberserk",
-                "description": "Berserk variant of the Fetlar rules with knights and commanders. Multiple captures are permitted, and the king may escape to the corner immediately after a capture."
+                "description": "Berserk variant of the Fetlar rules with knights and commanders. Multi-step captures are permitted, and the king may escape to the corner immediately after a capture."
             },
             "tyr-11x11-tyr": {
                 "name": "tyr-11x11-tyr",
-                "description": "Berserk rules with weak armed king and edge escape on a 11x11 board. This is the simple setup without special pieces."
+                "description": "Berserk rules with weak armed king and edge escape on a 11x11 board. This is the default simple setup without special pieces."
             },
             "tyr-15x15-tyr": {
                 "name": "tyr-15x15-tyr",
-                "description": "Berserk rules with weak armed king and edge escape on a 15x15 board. This is the simple setup without special pieces."
+                "description": "Berserk rules with weak armed king and edge escape on a 15x15 board. This is the default simple setup without special pieces."
             },
             "seabattle-9x9-starsquare-w": {
                 "name": "seabattle-9x9-starsquare-w",
@@ -1838,7 +1838,7 @@
             },
             "magpie-7x7-cross": {
                 "name": "magpie-7x7-cross",
-                "description": "A Tafl variant from the book The Leprechaun Companion by Nigel Suckling. It has a strong armed King that only moves one space. The king can be captured on the edges. Find the rules here: http://tafl.cyningstan.com/download/968/magpie-leaflet"
+                "description": "A Hnefatafl variant from the book The Leprechaun Companion by Nigel Suckling. It has a strong armed King that only moves one space. The king can be captured on the edges."
             }
         },
         "taiji": {

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -40,7 +40,7 @@ interface IPiece {
       berserkEscape?: boolean;
 }
 
-const defaultVariant = "historical-9x9-tcross-w";
+const defaultVariant = "linnaean-9x9-tcross-w";
 
 export class TaflGame extends GameBase {
     public static readonly gameinfo: APGamesInformation = {
@@ -58,9 +58,9 @@ export class TaflGame extends GameBase {
         ],
         people: [],
         variants: [
-            // default: "historical-9x9-tcross-w"
-            { uid: "historical-11x11-belldiamond-w", group: "variant" },
-            { uid: "historical-11x11-lewiscross-w", group: "variant" },
+            // default: "linnaean-9x9-tcross-w"
+            { uid: "linnaean-11x11-belldiamond-w", group: "variant" },
+            { uid: "linnaean-11x11-lewiscross-w", group: "variant" },
             { uid: "copenhagen-11x11-tdiamond", group: "variant" },
             { uid: "berserk-11x11-tdiamondberserk", group: "variant" },
             { uid: "tyr-11x11-tyr", group: "variant" },
@@ -121,7 +121,7 @@ export class TaflGame extends GameBase {
                 state = JSON.parse(state, reviver) as ITaflState;
             }
             if (state.game !== TaflGame.gameinfo.uid) {
-                throw new Error(`The Tafl game code cannot process a game of '${state.game}'.`);
+                throw new Error(`The Hnefatafl game code cannot process a game of '${state.game}'.`);
             }
             this.gameover = state.gameover;
             this.winner = [...state.winner];

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -53,7 +53,7 @@ export class TaflGame extends GameBase {
         // i18next.t("apgames:notes.tafl")
         notes: "apgames:notes.tafl",
         urls: [
-            "https://abstractplay.com/wiki/doku.php?id=tafl",
+            "https://abstractplay.com/wiki/doku.php?id=hnefatafl",
             "http://aagenielsen.dk/tafl_rules.php",
         ],
         people: [],

--- a/src/games/tafl/ruleset.d.ts
+++ b/src/games/tafl/ruleset.d.ts
@@ -11,7 +11,7 @@
 export type Urllist = string[];
 
 /**
- * When requested, the games library will produce the following information about Tafl rulesets
+ * When requested, the games library will produce the following information about Hnefatafl rulesets
  */
 export interface Ruleset {
   /**

--- a/src/games/tafl/ruleset.json
+++ b/src/games/tafl/ruleset.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/schema#",
     "$id": "https://www.abstractplay.com/schemas/gameinfo/1-0-0.json#",
     "title": "Ruleset",
-    "description": "When requested, the games library will produce the following information about Tafl rulesets",
+    "description": "When requested, the games library will produce the following information about Hnefatafl rulesets",
     "definitions": {
         "urllist": {
             "type": "array",

--- a/src/games/tafl/settings.ts
+++ b/src/games/tafl/settings.ts
@@ -13,10 +13,10 @@ export class TaflSettings {
     constructor(variant: string) {
         const [ruleset, boardSize, boardSetup, firstPlayer] = variant.split("-");
         switch (ruleset) {
-            case "historical":
+            case "linnaean":
                 this.ruleset = TaflSettings.createRuleset({
-                    name: "Historical",
-                    uid: "historical",
+                    name: "Linnaean",
+                    uid: "linnaean",
                     urls: [
                         "http://aagenielsen.dk/historical_hnefatafl_rules.php",
                     ],
@@ -288,8 +288,8 @@ export class TaflSettings {
     private static createRuleset(ruleset: Ruleset): Ruleset {
         // If anything is not defined, set it to the default value.
         // It is defined here because `Ruleset` is a generated interface.
-        // The default values should match "historical".
-        // Otherwise "fetlar" for properties that are turned off for "historical".
+        // The default values should match "linnaean".
+        // Otherwise "fetlar" for properties that are turned off for "linnaean".
         // Corner and throne are hostile, and edge is not by default.
         ruleset.escapeType ??= "edge";
         ruleset.pieces ??= {};


### PR DESCRIPTION
The term "historical" is not actually that descriptive, and I don't really want to make claims about it being the only historical variant, or if it's the "correct" historical ruleset; just that it's the rules as described by Linnaeus. The way it's implemented, the variant name fully defines the ruleset, so if we want to later implement a different "historical" variant, it could be a bit confusing.