### PR TITLE
Blockade: Optionally allow walls to be displayed in different colours.

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -2065,6 +2065,12 @@
                 "name": "Pips"
             }
         },
+        "blockade": {
+            "differentiated-walls": {
+                "description": "Display walls placed by each player in different colours.",
+                "name": "Differentated walls"
+            }
+        },
         "blooms": {
             "hide-threatened": {
                 "description": "Don't show threatened stones.",


### PR DESCRIPTION
Changing the walls on the board to be recorded as a map to playerid instead of just a set. It doesn't make a difference in gameplay, but sometimes it's just interesting to be reminded of who placed a particular wall. Not backwards compatible with previous version because of data structure change.

I note that there isn't a way to pass the renderer options to `getPlayerStash` to adjust the colours accordingly. I wanted to set the colour of the horizontal and vertical bars to #000000, but it doesn't display very well in dark mode. Left it as player 3 colour for now.