### PR TITLE
Piece count

### DIFF
--- a/src/games/archimedes.ts
+++ b/src/games/archimedes.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -37,7 +37,7 @@ export class ArchimedesGame extends GameBase {
                 name: "Philip Cohen"
             }
         ],
-        flags: ["perspective", "pie"],
+        flags: ["perspective", "pie", "limited-pieces"],
         variants: [
             {uid: "8x10"}
         ],
@@ -635,6 +635,31 @@ export class ArchimedesGame extends GameBase {
                 break;
         }
         return resolved;
+    }
+
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(p => p === player).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
+    public status(): string {
+        let status = super.status();
+
+        if (this.variants !== undefined) {
+            status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
+        }
+
+        return status;
     }
 
     public clone(): ArchimedesGame {

--- a/src/games/breakthrough.ts
+++ b/src/games/breakthrough.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -44,7 +44,7 @@ export class BreakthroughGame extends GameBase {
                 uid: "bombardment"
             }
         ],
-        flags: ["perspective"]
+        flags: ["perspective", "limited-pieces"]
     };
     public static coords2algebraic(x: number, y: number): string {
         return GameBase.coords2algebraic(x, y, 8);
@@ -545,11 +545,26 @@ export class BreakthroughGame extends GameBase {
         return rep;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(p => p === player).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/courtesan.ts
+++ b/src/games/courtesan.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -41,7 +41,7 @@ export class CourtesanGame extends GameBase {
         variants: [
             {uid: "size-6", group: "board"}
         ],
-        flags: ["pie", "multistep", "perspective"],
+        flags: ["pie", "multistep", "perspective", "limited-pieces"],
     };
 
     public coords2algebraic(x: number, y: number): string {
@@ -592,11 +592,26 @@ export class CourtesanGame extends GameBase {
         return rep;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(([owner,]) => owner === player).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/epam.ts
+++ b/src/games/epam.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -41,7 +41,7 @@ export class EpamGame extends GameBase {
                 group: "setup"
             }
         ],
-        flags: ["perspective"]
+        flags: ["perspective", "limited-pieces"]
     };
 
     public static coords2algebraic(x: number, y: number): string {
@@ -652,11 +652,26 @@ export class EpamGame extends GameBase {
         return rep;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(p => p === player).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/furl.ts
+++ b/src/games/furl.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -43,7 +43,7 @@ export class FurlGame extends GameBase {
                 urls: ["http://www.mrraow.com"]
             }
         ],
-        flags: ["multistep", "check", "perspective", "aiai"],
+        flags: ["multistep", "check", "perspective", "aiai", "limited-pieces"],
         variants: [
             // { uid: "size-5", group: "board" },
         ],
@@ -449,7 +449,6 @@ export class FurlGame extends GameBase {
                 this.results.push({type: "capture", count: size, where: to});
             }
         }
-        this.board.set(m, [this.currplayer, 1]);
 
         // update currplayer
         this.lastmove = m;
@@ -649,11 +648,26 @@ export class FurlGame extends GameBase {
         return resolved;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(v => v[0] === player).map(v => v[1]).reduce((a, b) => a + b, 0);
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/furl.ts
+++ b/src/games/furl.ts
@@ -32,7 +32,8 @@ export class FurlGame extends GameBase {
         name: "Furl",
         uid: "furl",
         playercounts: [2],
-        version: "20231229",
+        // version: "20231229",
+        version: "20240309",
         // i18next.t("apgames:descriptions.furl")
         description: "apgames:descriptions.furl",
         urls: ["https://boardgamegeek.com/boardgame/325422/furl"],
@@ -653,6 +654,7 @@ export class FurlGame extends GameBase {
     }
 
     public getPlayersScores(): IScores[] {
+        if (this.stack[0]._version === "20231229") { return []; }
         return [
             { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
         ]

--- a/src/games/hens.ts
+++ b/src/games/hens.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -41,7 +41,7 @@ export class HensGame extends GameBase {
         variants: [
             { uid: "size-10" }
         ],
-        flags: ["multistep", "perspective"]
+        flags: ["multistep", "perspective", "limited-pieces"]
     };
 
     public coords2algebraic(x: number, y: number): string {
@@ -748,11 +748,26 @@ export class HensGame extends GameBase {
         return rep;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(([owner,]) => owner === player).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/lielow.ts
+++ b/src/games/lielow.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -47,7 +47,7 @@ export class LielowGame extends GameBase {
                 name: "Alek Erickson",
             },
         ],
-        flags: ["multistep", "perspective", "aiai"]
+        flags: ["multistep", "perspective", "aiai", "limited-pieces"]
     };
 
     public coords2algebraic(x: number, y: number): string {
@@ -577,7 +577,7 @@ export class LielowGame extends GameBase {
                 width: this.boardSize,
                 height: this.boardSize,
                 buffer: {
-                    width: 0.5,
+                    width: 0.2,
                     pattern: "slant",
                     show: ["N", "E", "S", "W"],
                 },
@@ -691,11 +691,26 @@ export class LielowGame extends GameBase {
         return result;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(v => v[0] === player).map(v => v[1]).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/loa.ts
+++ b/src/games/loa.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -45,7 +45,7 @@ export class LinesOfActionGame extends GameBase {
                 group: "board"
             }
         ],
-        flags: ["multistep", "check"]
+        flags: ["multistep", "check", "limited-pieces"]
     };
 
     public numplayers = 2;
@@ -586,11 +586,26 @@ export class LinesOfActionGame extends GameBase {
         return rep;
     }
 
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(x => x === player).length;
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
     public status(): string {
         let status = super.status();
 
         if (this.variants !== undefined) {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
         }
 
         return status;

--- a/src/games/monkey.ts
+++ b/src/games/monkey.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IScores, IValidationResult } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APRenderRep } from "@abstractplay/renderer/src/schemas/schema";
 import { APMoveResult } from "../schemas/moveresults";
@@ -39,7 +39,7 @@ export class MonkeyQueenGame extends GameBase {
                 urls: ["http://www.marksteeregames.com/"]
             },
         ],
-        flags: ["pie","perspective", "check"]
+        flags: ["pie", "perspective", "check", "limited-pieces"]
     };
 
     public static coords2algebraic(x: number, y: number): string {
@@ -583,6 +583,31 @@ export class MonkeyQueenGame extends GameBase {
             }
         }
         return checked;
+    }
+
+    public getPlayerPieces(player: number): number {
+        return [...this.board.values()].filter(e => e[0] === player).map(e => e[1]).reduce((a,b) => a + b, 0);
+    }
+
+    public getPlayersScores(): IScores[] {
+        return [
+            { name: i18next.t("apgames:status.PIECESREMAINING"), scores: [this.getPlayerPieces(1), this.getPlayerPieces(2)] }
+        ]
+    }
+
+    public status(): string {
+        let status = super.status();
+
+        if (this.variants !== undefined) {
+            status += "**Variants**: " + this.variants.join(", ") + "\n\n";
+        }
+
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
+        }
+
+        return status;
     }
 
     public clone(): MonkeyQueenGame {

--- a/src/games/reversi.ts
+++ b/src/games/reversi.ts
@@ -750,6 +750,10 @@ export class ReversiGame extends GameBase {
                 node.push(i18next.t("apresults:CAPTURE.reversi", {count: r.count}));
                 resolved = true;
                 break;
+            case "pass":
+                node.push(i18next.t("apresults:PASS.forced", {player}));
+                resolved = true;
+                break;
         }
         return resolved;
     }

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -1426,6 +1426,11 @@ export class TaflGame extends GameBase {
             status += "**Variants**: " + this.variants.join(", ") + "\n\n";
         }
 
+        status += "**Pieces On Board:**\n\n";
+        for (let n = 1; n <= this.numplayers; n++) {
+            status += `Player ${n}: ${this.getPlayerPieces(n)}\n\n`;
+        }
+
         return status;
     }
 


### PR DESCRIPTION
Adding material balance count for

* Archimedes
* Breakthrough
* King & Courtesan
* Epaminondas
* Furl
* Hens and Chicks
* Lielow
* Lines of Action
* Monkey Queen

It was added to Hnefatafl in a previous commit.

Some things to note:
* I found a weird line in Furl where it was adding moves to the board. Made this discovery when there were  It's likely an older code that was left there. Didn't have any impact on the games, but the older records has a bit of junk in them... Games started with an older version will not have the piece count display because of that.
* I decreased the buffer size for Lielow. I don't think it's a move that people make often anyway. It's just there to make the game rules elegant to work with the no-pass rule.
* Not relevant, but Reversi was missing chat messages for forced pass.