### PR TITLE
Hnefatafl: Add total variant

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -2026,6 +2026,10 @@
                 "name": "berserk-11x11-tdiamondberserk",
                 "description": "Berserk variant of the Fetlar rules with knights and commanders. Multi-step captures are permitted, and the king may escape to the corner immediately after a capture."
             },
+            "total-11x11-tdiamond": {
+                "name": "total-11x11-tdiamond",
+                "description": "A combination of Fetlar, Copenhagen and Berserk rules. It is a strong armed king with corner escape rules, with shield wall captures, exit forts, and encirclement win. Berserk capture is enabled and the king can make a berserk escape. Repetitions result in a draw."
+            },
             "tyr-11x11-tyr": {
                 "name": "tyr-11x11-tyr",
                 "description": "Berserk rules with weak armed king and edge escape on a 11x11 board. This is the default simple Tyr setup without special pieces."

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -64,6 +64,7 @@ export class TaflGame extends GameBase {
             { uid: "linnaean-11x11-lewiscross-w", group: "variant" },
             { uid: "copenhagen-11x11-tdiamond", group: "variant" },
             { uid: "berserk-11x11-tdiamondberserk", group: "variant" },
+            { uid: "total-11x11-tdiamond", group: "variant" },
             { uid: "tyr-11x11-tyr", group: "variant" },
             { uid: "tyr-15x15-tyr", group: "variant" },
             { uid: "seabattle-9x9-starsquare-w", group: "variant" },

--- a/src/games/tafl/settings.ts
+++ b/src/games/tafl/settings.ts
@@ -88,13 +88,30 @@ export class TaflSettings {
                         "http://aagenielsen.dk/berserk_rules.php",
                     ],
                     escapeType: "corner",
-                    pieces: { king: { strength: "strong", jump: "jump-enemy-taflmen-to-from-restricted", berserkEscape: true } },
+                    pieces: { king: { strength: "strong", berserkEscape: true } },
                     throne: { emptyAnvilTo: "all" },
                     corner: { type: "corner", anvilTo: "men-only-piercing" },
                     berserkCapture: true,
                     encirclementWin: false,
                 });
                 break;
+            case "total":
+                this.ruleset = TaflSettings.createRuleset({
+                    name: "Total",
+                    uid: "terserk",
+                    urls: [],
+                    escapeType: "corner",
+                    pieces: { king: { strength: "strong", jump: "jump-enemy-taflmen-to-from-restricted", berserkEscape: true } },
+                    throne: { emptyAnvilTo: "all" },
+                    corner: { type: "corner", anvilTo: "men-only-piercing" },
+                    berserkCapture: true,
+                    encirclementWin: false,
+                    hasShieldWalls: true,
+                    hasExitForts: true,
+                    repetition: "draw",
+                });
+                break;
+
             case "tyr":
                 this.ruleset = TaflSettings.createRuleset({
                     name: "Tyr",


### PR DESCRIPTION
Total Hnefatafl is a combination of Fetlar, Copenhagen and Berserk rules. It is a strong armed king with corner escape rules, with shield wall captures, exit forts, and encirclement win. Berserk capture is enabled and the king can make a berserk escape. Repetitions result in a draw.