### PR TITLE
Fix stateCount and generalised the implementation.

### DIFF
--- a/src/games/_base.ts
+++ b/src/games/_base.ts
@@ -785,35 +785,27 @@ export abstract class GameBase  {
 
     // compares the most recent state to all previous states and returns
     // the number of times the state has been repeated
-    // arguments are optional. if provided, it will override the current state
-    public stateCount(board: any = undefined, currplayer: number | undefined = undefined): number {
+    // Provide a dictionary of the properties to check in the state, and the
+    // instances of that property to check for occurence in the stack.
+    public stateCount(toCheck: Map<string, any>): number {
         const stack = [...this.stack];
-        const comparator = stack.pop();
-        board ??= comparator?.board;
-        currplayer ??= comparator?.currplayer;
         let count = 0;
-        if (comparator !== undefined) {
-            if ("board" in comparator && "currplayer" in comparator) {
-                const srcStr = JSDstringify({
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    board,
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    currplayer,
-                }, {replacer: sortingReplacer});
-                for (const state of stack) {
-                    const test = {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        board: state.board,
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        currplayer: state.currplayer,
-                    }
-                    const otherStr = JSDstringify(test, {replacer: sortingReplacer});
-                    if (srcStr === otherStr) {
-                        count++;
-                    }
-                }
-            } else {
-                throw new Error("State counting only works if `board` and `currplayer` are part of the state.");
+        // If any of the keys of toCheck does not exist in the state, throw an error
+        for (const key of toCheck.keys()) {
+            if (!stack[0].hasOwnProperty(key)) {
+                throw new Error(`The key ${key} does not exist in the state.`);
+            }
+        }
+        const srcStr = JSDstringify(toCheck, { replacer: sortingReplacer });
+        for (const state of stack) {
+            const test = new Map<string, any>();
+            for (const key of toCheck.keys()) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                test.set(key, state[key]);
+            }
+            const otherStr = JSDstringify(test, { replacer: sortingReplacer });
+            if (srcStr === otherStr) {
+                count++;
             }
         }
         return count;

--- a/src/games/anache.ts
+++ b/src/games/anache.ts
@@ -758,7 +758,7 @@ export class AnacheGame extends GameBase {
                 }
             }
         }
-        const count = this.stateCount(newBoard, this.currplayer % 2 + 1 as playerid);
+        const count = this.stateCount(new Map<string, any>([["board", newBoard], ["currplayer", this.currplayer % 2 + 1]]));
         // Handling of partial group moves.
         if (isDragonMove) {
             if (dragonContinue) {

--- a/src/games/asli.ts
+++ b/src/games/asli.ts
@@ -543,7 +543,7 @@ export class AsliGame extends GameBase {
         if (this.stack.length > 3) {
             let stateCount = 0;
             if (this.stack[this.stack.length - 2].lastmove !== "pass") {
-                stateCount = this.stateCount();
+                stateCount = this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]]));
             }
 
             if (stateCount > 0) {

--- a/src/games/ataxx.ts
+++ b/src/games/ataxx.ts
@@ -607,7 +607,7 @@ export class AtaxxGame extends GameBase {
     }
 
     protected checkEOG(): AtaxxGame {
-        const stateCount = this.stateCount();
+        const stateCount = this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]]));
         if (!this.hasMoves(this.currplayer)) {
             const emptyCellCount = this.emptyCellCount();
             if (emptyCellCount > 0) {

--- a/src/games/ayu.ts
+++ b/src/games/ayu.ts
@@ -457,7 +457,7 @@ export class AyuGame extends GameBase {
             this.results.push({ type: "eog" });
         }
         if (!this.gameover) {
-            const count = this.stateCount();
+            const count = this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]]));
             if (count >= 1) {
                 this.gameover = true;
                 this.winner = [this.currplayer];

--- a/src/games/fanorona.ts
+++ b/src/games/fanorona.ts
@@ -600,7 +600,7 @@ export class FanoronaGame extends GameBase {
         }
 
         if (! this.gameover) {
-            const count = this.stateCount();
+            const count = this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]]));
             if (count >= 4) {
                 this.gameover = true;
                 this.winner = [1,2];

--- a/src/games/gonnect.ts
+++ b/src/games/gonnect.ts
@@ -402,7 +402,7 @@ export class GonnectGame extends GameBase {
             this.results.push({ type: "eog", reason: "stalemate" });
         }
         if (!this.gameover) {
-            const count = this.stateCount();
+            const count = this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]]));
             if (count >= 1) {
                 this.gameover = true;
                 this.winner = [this.currplayer];

--- a/src/games/hexentafl.ts
+++ b/src/games/hexentafl.ts
@@ -485,7 +485,7 @@ export class HexentaflGame extends GameBase {
             this.gameover = true;
             this.winner = [2];
             this.results.push({ type: "eog" });
-        } else if (this.stateCount() >= 2) {
+        } else if (this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]])) >= 2) {
             this.gameover = true;
             this.winner = [1, 2];
             this.results.push({ type: "eog", reason: "repetition" });

--- a/src/games/irensei.ts
+++ b/src/games/irensei.ts
@@ -595,7 +595,7 @@ export class IrenseiGame extends InARowBase {
             this.results.push({ type: "eog" });
         }
         if (!this.gameover) {
-            const count = this.stateCount();
+            const count = this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]]));
             if (count >= 1) {
                 this.gameover = true;
                 this.winner = [this.currplayer];

--- a/src/games/margo.ts
+++ b/src/games/margo.ts
@@ -633,7 +633,7 @@ export class MargoGame extends GameBase {
             }
             checkPlayer = checkPlayer % 2 + 1 as playerid;
         }
-        return this.stateCount(newBoard, player % 2 + 1 as playerid) >= 1;
+        return this.stateCount(new Map<string, any>([["board", newBoard], ["currplayer", player % 2 + 1]])) >= 1;
     }
 
     private checkKo(place: string, player: playerid, unsubmitted = false): boolean {

--- a/src/games/tafl.ts
+++ b/src/games/tafl.ts
@@ -1211,13 +1211,13 @@ export class TaflGame extends GameBase {
             this.gameover = true;
             this.winner = [this.playerDefender];
             this.results.push({ type: "eog", reason: "king-escaped" });
-        } else if (this.settings.ruleset.repetition === "defenders-lose" && this.currplayer === this.playerAttacker && this.stateCount() >= 2) {
+        } else if (this.settings.ruleset.repetition === "defenders-lose" && this.currplayer === this.playerAttacker && this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]])) >= 2) {
             // Perpetual repetitions is a loss for the defender.
             // But we only enforce it if defender player makes their turn.
             this.gameover = true;
             this.winner = [this.playerAttacker];
             this.results.push({ type: "eog", reason: "repetition" });
-        } else if (this.settings.ruleset.repetition === "draw" && this.stateCount() >= 2) {
+        } else if (this.settings.ruleset.repetition === "draw" && this.stateCount(new Map<string, any>([["board", this.board], ["currplayer", this.currplayer]])) >= 2) {
             this.gameover = true;
             this.winner = [1, 2];
             this.results.push({ type: "eog", reason: "repetition" });


### PR DESCRIPTION
I think the previous `stateCount` implementation was delayed by one move because it was checking for repetition with reference to the last item in the stack. But the `stateCount` method is called in `checkEOG`, which is called before`saveState`, so the new `board` and `currplayer` are not yet committed at that point. This means that once the repetition has been detected, it forced the next player to make one extra move before actually ending the game.

While making this fix, I also generalised what to check. Now, we just give the actual objects that we want to check against the properties in the state as a `Map<string, any>`, where the key is the name of the property and the value is the object to check. If we wish to check for situational supreko, we feed in the `board` and `currplayer`. If we wish to check for positional superko, we can just feed in the `board`. But this allows us to get it to check arbitrary objects like scores or anything else that represents the state besides the board.