### PR TITLE
Terrace: Load the results

### DIFF
--- a/src/games/terrace.ts
+++ b/src/games/terrace.ts
@@ -219,6 +219,7 @@ export class TerraceGame extends GameBase {
         }
 
         const state = this.stack[idx];
+        this.results = [...state._results];
         this.currplayer = state.currplayer;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         this.board = deepclone(state.board) as Map<string, TerracePiece>;


### PR DESCRIPTION
Don't know if there's a good reason for it, but the results are not loaded into the game object, so move annotations aren't being displayed.