### PR TITLE
Hula rules update

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,4 +1,5 @@
 import { RectGrid } from "./rectGrid";
+import { StackSet} from "./stackset";
 import { reviver, replacer, sortingReplacer } from "./serialization";
 import { shuffle } from "./shuffle";
 import { UserFacingError } from "./errors";
@@ -9,7 +10,7 @@ import { hexhexAi2Ap, hexhexAp2Ai, triAi2Ap, triAp2Ai } from "./aiai";
 import stringify from "json-stringify-deterministic";
 import fnv from "fnv-plus";
 
-export { RectGrid, reviver, replacer, sortingReplacer, shuffle, UserFacingError, HexTriGraph, SnubSquareGraph, SquareOrthGraph, SquareDiagGraph, SquareGraph, Square3DGraph, SquareDirectedGraph, SquareFanoronaGraph, BaoGraph, SowingNoEndsGraph, wng, projectPoint, ptDistance, smallestDegreeDiff, normDeg, deg2rad, rad2deg, toggleFacing, calcBearing, matrixRectRot90, matrixRectRotN90, transposeRect, hexhexAi2Ap, hexhexAp2Ai, triAi2Ap, triAp2Ai, circle2poly, midpoint, distFromCircle };
+export { RectGrid, StackSet, reviver, replacer, sortingReplacer, shuffle, UserFacingError, HexTriGraph, SnubSquareGraph, SquareOrthGraph, SquareDiagGraph, SquareGraph, Square3DGraph, SquareDirectedGraph, SquareFanoronaGraph, BaoGraph, SowingNoEndsGraph, wng, projectPoint, ptDistance, smallestDegreeDiff, normDeg, deg2rad, rad2deg, toggleFacing, calcBearing, matrixRectRot90, matrixRectRotN90, transposeRect, hexhexAi2Ap, hexhexAp2Ai, triAi2Ap, triAp2Ai, circle2poly, midpoint, distFromCircle };
 
 export type DirectionCardinal = "N" | "E" | "S" | "W";
 export type DirectionDiagonal = "NE" | "SE" | "SW" | "NW";

--- a/src/common/stackset.ts
+++ b/src/common/stackset.ts
@@ -1,0 +1,40 @@
+/**
+ * A StackSet helper class.
+ * Converted from graphology source.
+ */
+export class StackSet {
+    set: Set<string> = new Set<string>();
+    stack: string[] = [];
+
+    has(value: string): boolean {
+        return this.set.has(value);
+    }
+
+    push(value: string): void {
+        this.stack.push(value);
+        this.set.add(value);
+    }
+
+    pop(): void {
+        this.set.delete(this.stack.pop() as string);
+    }
+
+    path(value: string): string[] {
+        return this.stack.concat(value);
+    }
+
+    static of(value: string, cycle: boolean): StackSet{
+        const set = new StackSet();
+
+        if (!cycle) {
+            // Normally we add source both to set & stack
+            set.push(value);
+        } else {
+            // But in case of cycle, we only add to stack so that we may reach the
+            // source again (as it was not already visited)
+            set.stack.push(value);
+        }
+
+        return set;
+    }
+}

--- a/test/games/hula.test.ts
+++ b/test/games/hula.test.ts
@@ -1,0 +1,180 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import "mocha";
+import { expect } from "chai";
+import { HulaGame } from '../../src/games';
+
+function state(p1s: string[], p2s: string[], neutrals: string[]): HulaGame {
+    let g = new HulaGame();
+    for(const m of p1s){
+        g.board.set(m, 1);
+    }
+    for(const m of p2s){
+        g.board.set(m, 2);
+    }
+    for(const m of neutrals){
+        g.board.set(m, 'neutral');
+    }
+    return g;
+}
+
+/* Various end conditions.
+Test with both p1 and p2 as the current player:
+current player wins with normal stone
+neutral stone, current player wins with only loop
+neutral stone, other player wins with only loop
+neutral stone, current player wins with shortest loop
+neutral stone, other player wins with shortest loop
+neutral stone, current player wins with equally long loop but fewer neutrals
+neutral stone, other player wins with equally long loop but fewer neutrals
+neutral stone, two loops of equal size and #neutrals, p2 wins
+*/
+
+describe("Hula", () => {
+    it("p1 win with partisan stone placement", () => {
+        let g = state(
+            ['g5', 'g6', 'f5', 'f7', 'e5'],
+            [],
+            []);
+        g.move('e6');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p2 win with partisan stone placement", () => {
+        let g = state(
+            [],
+            ['g5', 'g6', 'f5', 'f7', 'e5'],
+            []);
+        g.move('e7');
+        g.move('e6');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+    it("p1 win with neutral stone placed by p1", () => {
+        let g = state(
+            ['g5', 'g6', 'f5', 'e5', 'e6',
+            'f8', 'f9', 'f10', 'f11'],
+            [],
+            []);
+        g.move('f7');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p1 win with neutral stone placed by p2", () => {
+        let g = state(
+            ['g5', 'g6', 'f5', 'e5', 'e6'],
+            ['f8', 'f9', 'f10', 'f11'],
+            []);
+        g.move('a1');
+        g.move('f7');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p1 win with shortest loop, neutral stone placed by p1", () => {
+        let g = state(
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6',
+            'i4', 'j4', 'k4'],
+            ['h4', 'g4', 'g3', 'f3', 'e3', 'e4', 'd4', 'g6', 'f7', 'e6'],
+            ['d5']);
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p1 win with shortest loop, neutral stone placed by p2", () => {
+        let g = state(
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6'],
+            ['h4', 'g4', 'g3', 'f3', 'e3', 'e4', 'd4', 'g6', 'f7', 'e6',
+            'i4', 'j4', 'k4'],
+            ['d5']);
+        g.move('a1');
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p2 win with shortest loop, neutral stone placed by p2", () => {
+        let g = state(
+            ['h4', 'g4', 'g3', 'f3', 'e3', 'e4', 'd4', 'g6', 'f7', 'e6'],
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6',
+            'i4', 'j4', 'k4'],
+            ['d5']);
+        g.move('a1');
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+    it("p2 win with shortest loop, neutral stone placed by p1", () => {
+        let g = state(
+            ['h4', 'g4', 'g3', 'f3', 'e3', 'e4', 'd4', 'g6', 'f7', 'e6',
+            'i4', 'j4', 'k4'],
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6'],
+            ['d5']);
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+    it("p1 win with equally long loops but fewer neutrals, neutral stone placed by p1", () => {
+        let g = state(
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6',
+            'i4', 'j4', 'k4'],
+            ['h4', 'g4', 'e4', 'd4', 'g6', 'f7', 'e6'],
+            ['d5', 'f4']);
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p1 win with equally long loops but fewer neutrals, neutral stone placed by p2", () => {
+        let g = state(
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6'],
+            ['h4', 'g4', 'e4', 'd4', 'g6', 'f7', 'e6',
+            'i4', 'j4', 'k4'],
+            ['d5', 'f4']);
+        g.move('a1');
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([1]);
+    });
+    it("p2 win with equally long loops but fewer neutrals, neutral stone placed by p1", () => {
+        let g = state(
+            ['g5', 'f5', 'h6', 'g7', 'f8', 'e7', 'd6',
+            'i4', 'j4', 'k4'],
+            ['h4', 'g4', 'f4', 'e4', 'd4', 'g6', 'f7', 'e6'],
+            ['d5', 'e5']);
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+    it("p2 win with equally long loops but fewer neutrals, neutral stone placed by p2", () => {
+        let g = state(
+            ['g5', 'f5', 'h6', 'g7', 'f8', 'e7', 'd6'],
+            ['h4', 'g4', 'f4', 'e4', 'd4', 'g6', 'f7', 'e6',
+            'i4', 'j4', 'k4'],
+            ['d5', 'e5']);
+        g.move('a1');
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+    it("p2 win with equally long loops and equal number of neutrals, neutral stone placed by p1", () => {
+        let g = state(
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6',
+            'i4', 'j4', 'k4'],
+            ['h4', 'g4', 'f4', 'e4', 'd4', 'g6', 'f7', 'e6'],
+            ['d5']);
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+    it("p2 win with equally long loops and equal number of neutrals, neutral stone placed by p2", () => {
+        let g = state(
+            ['g5', 'f5', 'e5', 'h6', 'g7', 'f8', 'e7', 'd6'],
+            ['h4', 'g4', 'f4', 'e4', 'd4', 'g6', 'f7', 'e6',
+            'i4', 'j4', 'k4'],
+            ['d5']);
+        g.move('a1');
+        g.move('h5');
+        expect(g.gameover).to.be.true;
+        expect(g.winner).to.have.members([2]);
+    });
+});
+


### PR DESCRIPTION
Updated Hula to comply with the rules change in case of simultaneous loops.
 - New (more correct) algorithm to find the shortest loops
 - Winner is the shortest loop. If equal, the loop with fewer neutrals. If equal, p2 always wins. I've tested each case locally.