### PR TITLE
Cubeo variants

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -932,6 +932,22 @@
             "strict": {
                 "name": "Stricter movement constraints",
                 "description": "A valid move must materially change the formation, meaning the final formation can't just be a rotation/reflection of the starting formation."
+            },
+            "#dice": {
+                "name": "Default die size (d6)",
+                "description": "Each player has six d6, and the merge goal is 7."
+            },
+            "d7": {
+                "name": "d7",
+                "description": "Each player has seven 7-sided, yet cubical, dice, and the merge goal is 8."
+            },
+            "d8": {
+                "name": "d8",
+                "description": "Each player has eight 8-sided, yet cubical, dice, and the merge goal is 9."
+            },
+            "d9": {
+                "name": "d9",
+                "description": "Each player has nine 9-sided, yet cubical, dice, and the merge goal is 10."
             }
         },
         "dagnacht": {
@@ -3620,8 +3636,8 @@
             "BAD_MOVE_standard": "When moving, the die must move its full distance (though it may backtrack at any point), end in a space that keeps the formation connected, and may not end where it started.",
             "BAD_MOVE_strict": "When moving, the die must move its full distance (though it may backtrack at any point), end in a space that keeps the formation connected, and it must change the formation (meaning you can't move such that you simply create a rotation or reflection of the starting formation).",
             "BAD_PLACE": "You may only place new dice such that they share an edge with at least one of your own dice and do not share *any* edges with opposing dice. The die must also be able to be slid into the formation from the outside.",
-            "INITIAL_INSTRUCTIONS": "Click an empty cell to place a new die or one of your own dice to start a move or merge.",
-            "MAX_DICE": "You may only have six dice on the board.",
+            "INITIAL_INSTRUCTIONS": "Click an empty cell to place a new die, or one of your own dice to start a move or merge.",
+            "MAX_DICE": "You may only have {{dice}} dice on the board.",
             "PINNED": "Pinned dice can't act."
         },
         "dagnacht": {

--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -937,17 +937,17 @@
                 "name": "Default die size (d6)",
                 "description": "Each player has six d6, and the merge goal is 7."
             },
-            "d7": {
-                "name": "d7",
-                "description": "Each player has seven 7-sided, yet cubical, dice, and the merge goal is 8."
-            },
             "d8": {
                 "name": "d8",
                 "description": "Each player has eight 8-sided, yet cubical, dice, and the merge goal is 9."
             },
-            "d9": {
-                "name": "d9",
-                "description": "Each player has nine 9-sided, yet cubical, dice, and the merge goal is 10."
+            "d10": {
+                "name": "d10",
+                "description": "Each player has ten 10-sided, yet cubical, dice, and the merge goal is 11."
+            },
+            "d12": {
+                "name": "d12",
+                "description": "Each player has twelve 12-sided, yet cubical, dice, and the merge goal is 13."
             }
         },
         "dagnacht": {

--- a/src/games/cubeo.ts
+++ b/src/games/cubeo.ts
@@ -15,7 +15,7 @@ const deepclone = require("rfdc/default");
 
 export type playerid = 1|2;
 // 0 means >6, and therefore a winning merge
-export type Pips = 1|2|3|4|5|6|0;
+export type Pips = 1|2|3|4|5|6|7|8|9|0;
 
 export type NodeData = {
     contents?: CubeoDie;
@@ -66,7 +66,10 @@ export class CubeoGame extends GameBase {
             },
         ],
         variants: [
-            {uid: "strict", group: "moves"}
+            {uid: "strict", group: "moves"},
+	    {uid: "d7", group: "dice"},
+	    {uid: "d8", group: "dice"},
+	    {uid: "d9", group: "dice"},
         ],
         categories: ["goal>immobilize", "goal>score>race", "mechanic>place", "mechanic>move", "board>dynamic", "board>shape>rect", "board>connect>rect", "components>dice"],
         flags: ["automove"]
@@ -82,6 +85,7 @@ export class CubeoGame extends GameBase {
     public results: Array<APMoveResult> = [];
     public dots: [number,number][] = [];
     private eogTriggered = false;
+    private diesize = 0;
 
     constructor(state?: ICubeoState | string, variants?: string[]) {
         super();
@@ -128,14 +132,30 @@ export class CubeoGame extends GameBase {
         this.board = CubeoBoard.deserialize(state.board);
         this.lastmove = state.lastmove;
         this.results = [...state._results];
+        this.diesize = this.getDieSize();
         return this;
+    }
+
+    private getDieSize(): number {
+        // Get die size from variants.
+        if ((this.variants !== undefined) && (this.variants.length > 0) && (this.variants[0] !== undefined) && (this.variants[0].length > 0)) {
+            const diceVariants = this.variants.filter(v => v.startsWith("d"));
+            if (diceVariants.length > 0) {
+                const size = diceVariants[0].match(/\d+/);
+                return parseInt(size![0], 10);
+            }
+            if (isNaN(this.diesize)) {
+                throw new Error(`Could not determine the die size from variant "${this.variants[0]}"`);
+            }
+        }
+        return 6;
     }
 
     public diceInHand(p?: playerid): number {
         if (p === undefined) {
             p = this.currplayer;
         }
-        return 6 - this.board.getDiceOf(p).length;
+        return this.diesize - this.board.getDiceOf(p).length;
     }
 
     public moves(): string[] {
@@ -331,7 +351,9 @@ export class CubeoGame extends GameBase {
         if (m.startsWith("+")) {
             if (this.diceInHand(this.currplayer) === 0) {
                 result.valid = false;
-                result.message = i18next.t("apgames:validation.cubeo.MAX_DICE");
+                result.message = i18next.t("apgames:validation.cubeo.MAX_DICE", {
+		    dice: this.diesize,
+		});
                 return result;
             } else {
                 result.valid = false;
@@ -441,7 +463,7 @@ export class CubeoGame extends GameBase {
             // otherwise merge
             else {
                 let newsize = fDie.pips + tDie.pips;
-                if (newsize > 6) {
+                if (newsize > this.diesize) {
                     newsize = 0;
                     this.eogTriggered = true;
                 }
@@ -546,7 +568,7 @@ export class CubeoGame extends GameBase {
         // build legend
         const legend: {[k: string]: Glyph} = {};
         for (const p of [1,2] as const) {
-            for (const size of [0,1,2,3,4,5,6] as const) {
+            for (const size of [0,1,2,3,4,5,6,7,8,9] as const) {
                 legend[`${p === 1 ? "A" : "B"}${size}`] = {
                     name: `d6-${size === 0 ? "empty" : size}`,
                     colour: p,

--- a/src/games/cubeo.ts
+++ b/src/games/cubeo.ts
@@ -14,8 +14,8 @@ import { Glyph } from "@abstractplay/renderer/build";
 const deepclone = require("rfdc/default");
 
 export type playerid = 1|2;
-// 0 means >6, and therefore a winning merge
-export type Pips = 1|2|3|4|5|6|7|8|9|0;
+// 0 means > diesize, and therefore a winning merge
+export type Pips = 1|2|3|4|5|6|7|8|9|10|11|12|0;
 
 export type NodeData = {
     contents?: CubeoDie;
@@ -67,9 +67,9 @@ export class CubeoGame extends GameBase {
         ],
         variants: [
             {uid: "strict", group: "moves"},
-	    {uid: "d7", group: "dice"},
 	    {uid: "d8", group: "dice"},
-	    {uid: "d9", group: "dice"},
+	    {uid: "d10", group: "dice"},
+	    {uid: "d12", group: "dice"},
         ],
         categories: ["goal>immobilize", "goal>score>race", "mechanic>place", "mechanic>move", "board>dynamic", "board>shape>rect", "board>connect>rect", "components>dice"],
         flags: ["automove"]
@@ -364,7 +364,7 @@ export class CubeoGame extends GameBase {
         // then moves and merges
         else {
             // check for partials first
-            if (/^\d,-?\d+,-?\d+$/.test(m)) {
+            if (/^\d+,-?\d+,-?\d+$/.test(m)) {
                 const [,x,y] = m.split(",").map(n => parseInt(n, 10));
                 const die = this.board.getDieAt(x,y);
                 // die exists
@@ -561,15 +561,15 @@ export class CubeoGame extends GameBase {
             if (die === undefined) {
                 return "-";
             } else {
-                return `${die.owner === 1 ? "A" : "B"}${die.pips}`;
+                return `${die.owner === 1 ? "A" : "B"}${die.pips.toString(16)}`;
             }
         })).map(r => r.join(",")).join("\n");
 
         // build legend
         const legend: {[k: string]: Glyph} = {};
         for (const p of [1,2] as const) {
-            for (const size of [0,1,2,3,4,5,6,7,8,9] as const) {
-                legend[`${p === 1 ? "A" : "B"}${size}`] = {
+            for (let size = 0; size <=  this.diesize; size++) {
+                legend[`${p === 1 ? "A" : "B"}${size.toString(16)}`] = {
                     name: `d6-${size === 0 ? "empty" : size}`,
                     colour: p,
                     scale: 1.15,

--- a/src/games/cubeo/board.ts
+++ b/src/games/cubeo/board.ts
@@ -360,7 +360,7 @@ export class CubeoBoard {
                 if (die === undefined) {
                     lst.push("-");
                 } else {
-                    lst.push([die.owner, die.pips].join(""))
+                    lst.push([die.owner, die.pips.toString(16)].join(""))
                 }
             }
             rep.push(lst);


### PR DESCRIPTION
I added Cubeo "dice" variants to play up to 8, 10, or 12 dice: 

```
            "#dice": {
                "name": "Default die size (d6)",
                "description": "Each player has six d6, and the merge goal is 7."
            },
            "d8": {
                "name": "d8",
                "description": "Each player has eight 8-sided, yet cubical, dice, and the merge goal is 9."
            },
            "d10": {
                "name": "d10",
                "description": "Each player has ten 10-sided, yet cubical, dice, and the merge goal is 11."
            },
            "d12": {
                "name": "d12",
                "description": "Each player has twelve 12-sided, yet cubical, dice, and the merge goal is 13."
            }
```

I took out the 7 and 9 variants when adding 10 and 12.   The 7/8/9 version was less of a code change and is possibly less buggy than the second commit.  (Not that I think there are still bugs, but just in case something comes up.)