### PR TITLE
Remove Stairs variant

### DIFF
--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -2086,14 +2086,6 @@
                 "name": "5x5 board"
             }
         },
-        "stairs": {
-            "#board": {
-                "name": "Size 6 board"
-            },
-            "size-8": {
-                "name": "Size 8 board"
-            }
-        },
         "stibro": {
             "size-5": {
                 "name": "Size 5 board"

--- a/src/games/stairs.ts
+++ b/src/games/stairs.ts
@@ -50,13 +50,7 @@ export class StairsGame extends GameBase {
         ],
         categories: ["goal>score>eog", "mechanic>move", "mechanic>stack", "board>shape>rect", "board>connect>rect", "components>simple>1per"],
         flags: ["experimental", "pie", "autopass", "scores"],
-        variants: [
-            { uid: "#board", },
-            {
-                uid: "size-8",
-                group: "board",
-            }
-        ]
+        variants: []
     };
 
     public numplayers = 2;


### PR DESCRIPTION
The larger board variant was by analogy with Pilastri, but it's much more tedious to play in Stairs so I think just the base game will do.  I can imagine interesting variants with randomized boards and going up just one size to 7x7, but I'm not inspired to add them unless the devisor or players express an interest.