### PR TITLE
Add designer of Gess

### DIFF
--- a/src/games/gess.ts
+++ b/src/games/gess.ts
@@ -37,6 +37,10 @@ export class GessGame extends GameBase {
         urls: ["https://boardgamegeek.com/boardgame/12862/gess"],
         people: [
             {
+                type: "designer",
+                name: "the Puzzles and Games Ring of the Archimedeans (the Cambridge University Mathematical Society)"
+            },
+            {
                 type: "coder",
                 name: "ypaul",
                 urls: [],


### PR DESCRIPTION
I think the other no-designer games should be marked as Traditional or some such, or the Designer title omitted from the front end meta game page when the field is omitted.  But this one was an easier fix.