### PR TITLE
Tanbo and Soccolot update

### DIFF
--- a/src/games/soccolot.ts
+++ b/src/games/soccolot.ts
@@ -75,7 +75,7 @@ export class SoccolotGame extends GameBase {
                 board = new Map<string, playerid>([ // initial setup
                     ["b1", 1], ["c1", 1], ["d1", 1], ["e1", 1], ["f1", 1], ["g1", 1],
                     ["b8", 2], ["c8", 2], ["d8", 2], ["e8", 2], ["f8", 2], ["g8", 2],
-                    ["d4", 3],
+                    ["e5", 3],
                 ]);
             } else {
                 board = new Map<string, playerid>([ // initial setup

--- a/src/games/tanbo.ts
+++ b/src/games/tanbo.ts
@@ -398,7 +398,7 @@ export class TanboGame extends GameBase {
             },
             legend: {
                 A: { name: "piece", colour: 1 },
-                B: { name: "piece", colour: 1 },
+                B: { name: "piece", colour: 2 },
             },
             pieces: pstr
         };


### PR DESCRIPTION
Tanbo had a wrong P2 color (due to the removal of method getPlayerColour)
Corrected setup for Soccolot's original ruleset (the Zillions implementation has an error, that was copied to this code)