### PR TITLE
Added Bagh Chal.

### DIFF
--- a/locales/de/apgames.json
+++ b/locales/de/apgames.json
@@ -22,6 +22,7 @@
     "attangle": "Attangle ist der letzte Teil von Dieter Steins Stapel-Trilogie. Platziere und bewege Steine, um Stapel zu bauen. Die erste Person, die drei Dreierstapel baut, gewinnt. Die Variante \"Grand Attangle\" ist ebenfalls enthalten.",
     "ayu": "Ein Vereinigungsspiel, bei dem sich schlangenartige Gruppen von Steinen auf ihre Freunde zubewegen und schließlich verschmelzen. Wenn du in deinem Zug keinen Zug machen kannst, gewinnst du. Dies tritt ein, wenn du nur noch eine Gruppe hast oder kein freier Pfad zwischen deinen Gruppen existiert.",
     "azacru": "Ein Gebietskontrollspiel, bei dem richtungsgebundene Steine über ein unterteiltes Brett navigieren, um Felder zu beanspruchen.",
+    "baghchal": "Ein traditionelles asymmetrisches Zwei-Spieler-Spiel aus Nepal. Die Tiger versuchen, 5 Ziegen durch Überspringen zu schlagen; die Ziegen versuchen, alle Tiger bewegungsunfähig zu machen.",
     "bamboo": "Platziere Steine so, dass keine Gruppe mehr Steine hat als die Anzahl deiner Gruppen auf dem Brett. Sei dann der letzte Spieler, der noch ziehen kann.",
     "bao": "Ein traditionelles Mancala-Säspiel aus Ostafrika, bei dem du versuchst, alle Steine aus der vorderen Reihe des Gegners zu eliminieren oder ihm keine legalen Züge zu lassen.",
     "basalt": "Ein dreieckiges Verbindungsspiel an der Flanke eines Vulkans, bei dem Lava und Basalt darum wetteifern, die drei Seiten zuerst zu verbinden.",
@@ -4804,6 +4805,12 @@
       "NO_CAPTURES": "Du darfst nicht auf ein Feld mit einem anderen Chevron ziehen.",
       "REORIENT": "Klicke auf ein benachbartes Feld oder eine Randzone, um die Richtung auszuwählen, in die du blicken möchtest.",
       "TOO_FAR": "Du kannst dich nicht weiter bewegen als deine Bewegungsreichweite (derzeit {{pom}})."
+    },
+    "baghchal": {
+      "INITIAL_INSTRUCTIONS_TIGER_MOVEMENT": "Wähle einen Tiger aus, um ihn zu ziehen.",
+      "INITIAL_INSTRUCTIONS_GOAT_MOVEMENT": "Wähle eine Ziege aus, um sie zu ziehen.",
+      "INITIAL_INSTRUCTIONS_GOAT_PLACEMENT": "Setze eine Ziege auf einen freien Kreuzungspunkt.",
+      "VALID_PARTIAL": "Wähle einen freien Kreuzungspunkt aus, um dorthin zu ziehen. Ziegen und Tiger können auf auf freie benachbarte (verbundene) Kreuzungspunkte ziehen. Tiger dürfen auch eine benachbarte Ziege überspringen und auf dem freien Kreuzungspunkt dahinter landen, jedoch können sie nur vorwärts, schräg vorwärts und seitwärts springen, niemals rückwärts oder schräg rückwärts."
     },
     "bamboo": {
       "BAD_PLACE": "Keine deiner Gruppen darf mehr Steine enthalten als die Anzahl der Gruppen deiner Farbe auf dem Spielplan.",

--- a/locales/de/apgames.json
+++ b/locales/de/apgames.json
@@ -4437,6 +4437,10 @@
     "asli": {
       "TERRITORY": "Territorium & Gefangene"
     },
+    "baghchal": {
+      "GOATS_IN_HAND": "Ziegen auf der Hand",
+      "GOATS_CAPTURED": "Ziegen geschlagen"
+    },
     "bao": {
       "BALANCE": "Materialbilanz"
     },

--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -22,6 +22,7 @@
         "attangle": "Attangle is the final entry in Dieter Stein's stacking trilogy. Place and move pieces to build stacks. First person to build three triple stacks wins. The \"Grand Attangle\" variant is also implemented.",
         "ayu": "Unification game where snaky groups of pieces crawl toward their friends and eventually coalesce. If you cannot make a move on your turn, you win. This occurs when you have only one group or there is no free path between any of your groups.",
         "azacru": "A territory-control game where directional pieces navigate a subdivided board to claim cells.",
+        "baghchal": "A traditional asymmetric two-player game from Nepal. The tiger player tries to capture 5 goats by jumping across them, the goat player tries to immobilize all tigers.",
         "bamboo": "Place stones such that no group has more pieces than the number of your groups on the board. Then, be the last player able to move.",
         "bao": "A traditional mancala-style sowing game from East Africa where you attempt to eliminate all pieces from the opposing front row or leave them with no legal moves.",
         "basalt": "A triangular connection game played on the side of a volcano, where lava and basalt vye to connect the three sides first.",
@@ -4803,6 +4804,12 @@
             "NO_CAPTURES": "You may not move onto a cell with another chevron.",
             "REORIENT": "Click a neighbouring cell or edge zone to select the direction you want to face.",
             "TOO_FAR": "You can't move further than your power of movement (currently {{pom}})."
+        },
+        "baghchal": {
+            "INITIAL_INSTRUCTIONS_TIGER_MOVEMENT": "Select a tiger to move.",
+            "INITIAL_INSTRUCTIONS_GOAT_MOVEMENT": "Select a goat to move.",
+            "INITIAL_INSTRUCTIONS_GOAT_PLACEMENT": "Place a goat onto an empty intersection.",
+            "VALID_PARTIAL": "Select an empty intersection to move to. Goats as well as tigers can move to any free adjacent (connected) intersection. Tigers may jump across a goat to the free intersection behind it, but jumps can only occur forwards, diagonally forwards or sideways, never backwards or diagonally backwards."
         },
         "bamboo": {
             "BAD_PLACE": "None of your groups may contain more stones than number of groups of your colour on the board.",

--- a/locales/en/apgames.json
+++ b/locales/en/apgames.json
@@ -4379,6 +4379,10 @@
         "asli": {
             "TERRITORY": "Territory & Prisoners"
         },
+        "baghchal": {
+            "GOATS_IN_HAND": "Goats in hand",
+            "GOATS_CAPTURED": "Goats captured"
+        },
         "bao": {
             "BALANCE": "Material balance"
         },

--- a/src/games/baghchal.ts
+++ b/src/games/baghchal.ts
@@ -1,4 +1,4 @@
-import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult, IStashEntry } from "./_base";
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult, IStatus } from "./_base";
 import { APGamesInformation } from "../schemas/gameinfo";
 import { APMoveResult } from "../schemas/moveresults";
 import { APRenderRep } from "@abstractplay/renderer/build/schemas/schema";
@@ -693,16 +693,12 @@ export class BaghChalGame extends GameBase {
         return rep;
     }
 
-    public getPlayerStash(player: number): IStashEntry[] | undefined {
-        if (player === 1) {
-            return [{ count: this.goatsInHand, glyph: { name: "piece", colour: player }, movePart: "" }];
-        }
-        else {
-            return [{ count: this.goatsCaptured, glyph: { name: "star-outline", colour: player }, movePart: "" }];
-        }
+    public sidebarStatuses(): IStatus[] {
+        return [
+            { key: i18next.t("apgames:status.baghchal.GOATS_IN_HAND"), value: [this.goatsInHand.toString()] },
+            { key: i18next.t("apgames:status.baghchal.GOATS_CAPTURED"), value: [this.goatsCaptured.toString()] },
+        ];
     }
-
-
 
     public clone(): BaghChalGame {
         return new BaghChalGame(this.serialize());

--- a/src/games/baghchal.ts
+++ b/src/games/baghchal.ts
@@ -421,7 +421,6 @@ export class BaghChalGame extends GameBase {
                 result.move = "";
             } else {
                 result.move = newmove;
-                result.canrender = true;
             }
             return result;
         } catch (e) {
@@ -457,12 +456,14 @@ export class BaghChalGame extends GameBase {
         if (validMoves.includes(m)) {
             result.valid = true;
             result.complete = 1;
+            result.canrender = true;
             result.message = i18next.t("apgames:validation._general.VALID_MOVE");
             return result;
         }
         if (validStarts.includes(m)) {
             result.valid = true;
             result.complete = -1
+            result.canrender = true;
             result.message = i18next.t("apgames:validation.baghchal.VALID_PARTIAL");
             return result;
         }

--- a/src/games/baghchal.ts
+++ b/src/games/baghchal.ts
@@ -178,7 +178,7 @@ export class BaghChalGame extends GameBase {
     public variants: string[] = [];
     public stack!: Array<IMoveState>;
     public results: Array<APMoveResult> = [];
-    private _points: [number, number][] = [];
+    private _dots: string[] =[];
 
     constructor(state?: IBaghChalState | string) {
         super();
@@ -228,6 +228,7 @@ export class BaghChalGame extends GameBase {
         this.goatsInHand = state.goatsInHand;
         this.goatsCaptured = state.goatsCaptured;
         this.lastmove = state.lastmove;
+        this.results = [...state._results]
         return this;
     }
 
@@ -260,6 +261,7 @@ export class BaghChalGame extends GameBase {
             throw new Error("Cannot place goat on non-empty cell.");
         }
         this.board.set(cell, {owner: 1, animal: "Goat", facingDirection: "N"}); // Goats by default face north, but their direction is irrelevant.
+        this.results.push({type: "place", where: cell, count: 1 });
         this.goatsInHand -= 1;
     }
 
@@ -280,6 +282,7 @@ export class BaghChalGame extends GameBase {
             throw Error("No piece here to move!");
         }
 
+        this.results.push({ type: "move", from: from, to: to, what: oldPiece.animal });
         const pair = new BaghChalCellPair(from, to);
         const [dX, dY] = pair.deltaVector();
         if ((Math.abs(dX) === 2) || (Math.abs(dY) === 2)) {
@@ -288,11 +291,13 @@ export class BaghChalGame extends GameBase {
             const prey = BaghChalGame.coords2algebraic(preyX, preyY);
             this.board.delete(prey);
             this.goatsCaptured += 1;
+            this.results.push({ type: "capture", where: prey, what: "Goat"});
         }
 
         const newPiece = { owner: oldPiece.owner, animal: oldPiece.animal, facingDirection: this.newDirection(from, to) };
         this.board.delete(from);
         this.board.set(to, newPiece);
+
     }
 
     public jumpsAvailable(from: string) {
@@ -416,6 +421,7 @@ export class BaghChalGame extends GameBase {
                 result.move = "";
             } else {
                 result.move = newmove;
+                result.canrender = true;
             }
             return result;
         } catch (e) {
@@ -485,16 +491,16 @@ export class BaghChalGame extends GameBase {
             }
         }
 
-        if (partial && !m.includes("-")) {
+        if (partial) {
             const start = m;
             const validMoves = this.moves()
                 .filter((vm) => { return vm.split("-")[0] === start});
             const validEnds = validMoves
                  .map((vm) => { return vm.split("-")[1] });
-            this._points = validEnds.map((ve) => {return BaghChalGame.algebraic2coords(ve);});
+            this._dots = validEnds;
             return this;
         } else {
-            this._points = [];
+            this._dots = [];
         }
 
         if (m.length === 2) {
@@ -507,7 +513,6 @@ export class BaghChalGame extends GameBase {
             this.executeMove(from, to);
         }
         this.results = [];
-
 
 
         this.lastmove = m;
@@ -655,9 +660,28 @@ export class BaghChalGame extends GameBase {
 
         rep.annotations = [];
 
-        if (this._points.length > 0) {
+        if (this.results.length > 0) {
+            for (const move of this.results) {
+                if (move.type === "place") {
+                    const [x, y] = BaghChalGame.algebraic2coords(move.where!);
+                    rep.annotations.push({ type: "enter", targets: [{ row: y, col: x }] });
+                } else if (move.type === "move") {
+                    const [fromX, fromY] = BaghChalGame.algebraic2coords(move.from);
+                    const [toX, toY] = BaghChalGame.algebraic2coords(move.to);
+                    rep.annotations.push({ type: "move", targets: [{ row: fromY, col: fromX }, { row: toY, col: toX }] });
+                } else if (move.type === "capture") {
+                    for (const cell of move.where!.split(",")) {
+                        const [x, y] = BaghChalGame.algebraic2coords(cell);
+                        rep.annotations.push({ type: "exit", targets: [{ row: y, col: x }] });
+                    }
+                }
+            }
+        }
+
+        if (this._dots.length > 0) {
             const points = [];
-            for (const [x, y] of this._points) {
+            for (const dot of this._dots) {
+                const [x, y] = BaghChalGame.algebraic2coords(dot);
                 points.push({ row: y, col: x });
             }
             rep.annotations.push({

--- a/src/games/baghchal.ts
+++ b/src/games/baghchal.ts
@@ -1,0 +1,684 @@
+import { GameBase, IAPGameState, IClickResult, IIndividualState, IValidationResult, IStashEntry } from "./_base";
+import { APGamesInformation } from "../schemas/gameinfo";
+import { APMoveResult } from "../schemas/moveresults";
+import { APRenderRep } from "@abstractplay/renderer/build/schemas/schema";
+import { SquareFanoronaGraph } from "../common/graphs";
+import { RectGrid, Direction, allDirections, reviver, UserFacingError } from "../common";
+import i18next from "i18next";
+
+export type playerid = 1 | 2;
+export type Animal = "Tiger" | "Goat";
+export type Piece = {
+    owner: playerid;
+    animal: Animal;
+    facingDirection: Direction;
+}
+
+export type Phase = "TigerMovement" | "GoatPlacement" | "GoatMovement";
+
+export class BaghChalCellPair {
+    public from: string;
+    public to: string;
+
+    constructor(from: string, to: string) {
+        this.from = from;
+        this.to = to;
+    }
+
+    public fromVector(): [number, number] {
+        return GameBase.algebraic2coords(this.from, 5);
+    }
+
+    public toVector(): [number, number] {
+        return GameBase.algebraic2coords(this.to, 5);
+    }
+
+    public fromX(): number {
+        return this.fromVector()[0];
+    }
+
+    public fromY(): number {
+        return this.fromVector()[1];
+    }
+
+    public toX(): number {
+        return this.toVector()[0];
+    }
+
+    public toY(): number {
+        return this.toVector()[1];
+    }
+
+    public deltaX(): number {
+        return this.toX() - this.fromX();
+    }
+
+    public deltaY(): number {
+        return this.toY() - this.fromY();
+    }
+
+    public deltaVector(): [number, number] {
+        return [this.deltaX(), this.deltaY()];
+    }
+
+    public deltaString(): string {
+        return `${this.deltaX()}|${this.deltaY()}`;
+    }
+
+    public direction(): Direction | undefined {
+        switch (this.deltaString()) {
+            case "0|-1":
+                return "N";
+            case "1|-1":
+                return "NE";
+            case "1|0":
+                return "E";
+            case "1|1":
+                return "SE";
+            case "0|1":
+                return "S";
+            case "-1|1":
+                return "SW";
+            case "-1|0":
+                return "W";
+            case "-1|-1":
+                return "NW";
+            default:
+                return undefined;
+        }
+    }
+}
+
+function cyclicWindow<T>(array: T[], value: T, radius: number) {
+    const i = array.indexOf(value);
+    if (i === -1) return [];
+
+    return Array.from({ length: 2 * radius + 1 }, (_, k) => {
+        const offset = k - radius;
+        return array[(i + offset + array.length) % array.length];
+    });
+}
+
+export function allowedDirections(facingDirection: Direction): Direction[] {
+    return cyclicWindow(allDirections, facingDirection, 2);
+}
+
+
+
+export interface IMoveState extends IIndividualState {
+    currplayer: playerid;
+    board: Map<string, Piece>;
+    goatsInHand: number;
+    goatsCaptured: number;
+    lastmove?: string;
+};
+
+
+export interface IBaghChalState extends IAPGameState {
+    winner: playerid[];
+    stack: Array<IMoveState>;
+};
+
+
+export class BaghChalGame extends GameBase {
+
+    public static readonly gameinfo: APGamesInformation = {
+        name: "Bagh Chal",
+        uid: "baghchal",
+        playercounts: [2],
+        version: "20260816",
+        dateAdded: "2026-08-16",
+        // i18next.t("apgames:descriptions.baghchal")
+        description: "apgames:descriptions.baghchal",
+        urls: [
+            "https://boardgamegeek.com/boardgame/315/bagh-chal",
+            "https://en.wikipedia.org/wiki/Bagh-chal",
+        ],
+        people: [
+            {
+                type: "coder",
+                name: "Fabian Stiewe (Girolamo Cardano)",
+                urls: [],
+                apid: "079d1f5f-e260-423d-b151-be95b152bf6d",
+            },
+        ],
+        categories: [
+            "goal>score>race",
+            "goal>immobilize",
+            "mechanic>place",
+            "mechanic>move",
+            "mechanic>capture",
+            "mechanic>asymmetry",
+        ],
+        flags: [
+            "player-stashes",
+        ]
+    };
+
+    public static coords2algebraic(x: number, y: number): string {
+        return GameBase.coords2algebraic(x, y, 5);
+    }
+    public static algebraic2coords(cell: string): [number, number] {
+        return GameBase.algebraic2coords(cell, 5);
+    }
+
+    public numplayers = 2;
+    public currplayer: playerid = 1;
+    public board!: Map<string, Piece>;
+    public grid: RectGrid = new RectGrid(5, 5);
+    public graph: SquareFanoronaGraph = new SquareFanoronaGraph(5, 5)
+    public goatsInHand: number = 20;
+    public goatsCaptured: number = 0;
+    public gameover = false;
+    public winner: playerid[] = [];
+    public variants: string[] = [];
+    public stack!: Array<IMoveState>;
+    public results: Array<APMoveResult> = [];
+    private _points: [number, number][] = [];
+
+    constructor(state?: IBaghChalState | string) {
+        super();
+        if (state === undefined) {
+            const board = new Map<string, Piece>([
+                ["a1", {owner: 2, animal: "Tiger", facingDirection: "NE"}],
+                ["e1", {owner: 2, animal: "Tiger", facingDirection: "NW"}],
+                ["a5", {owner: 2, animal: "Tiger", facingDirection: "SE"}],
+                ["e5", {owner: 2, animal: "Tiger", facingDirection: "SW"}],
+            ]);
+            const fresh: IMoveState = {
+                _version: BaghChalGame.gameinfo.version,
+                _results: [],
+                _timestamp: new Date(),
+                currplayer: this.currplayer,
+                board: board,
+                goatsInHand: this.goatsInHand,
+                goatsCaptured: this.goatsCaptured,
+            };
+            this.stack = [fresh];
+        } else {
+            if (typeof state === "string") {
+                state = JSON.parse(state, reviver) as IBaghChalState;
+            }
+            if (state.game !== BaghChalGame.gameinfo.uid) {
+                throw new Error(`The Bagh Chal engine cannot process a game of '${state.game}'.`);
+            }
+            this.gameover = state.gameover;
+            this.winner = [...state.winner];
+            this.variants = state.variants;
+            this.stack = [...state.stack];
+        }
+        this.load();
+    }
+
+    public load(idx = -1): BaghChalGame {
+        if (idx < 0) {
+            idx += this.stack.length;
+        }
+        if ((idx < 0) || (idx >= this.stack.length)) {
+            throw new Error("Could not load the requested state from the stack.");
+        }
+
+        const state = this.stack[idx];
+        this.currplayer = state.currplayer;
+        this.board = new Map(state.board);
+        this.goatsInHand = state.goatsInHand;
+        this.goatsCaptured = state.goatsCaptured;
+        this.lastmove = state.lastmove;
+        return this;
+    }
+
+    public emptyCells(): string[] {
+        return this.graph.graph.nodes().filter((cell) => !this.board.has(cell));
+    }
+
+    public goatsOnBoard(): string[] {
+        const result: string[] = [];
+        this.board.forEach((piece, cell) => {
+            if (piece.animal === "Goat") {
+                result.push(cell);
+            }
+        })
+        return result;
+    }
+
+    public tigersOnBoard(): Map<string, Direction> {
+        const result: Map<string, Direction> = new Map();
+        this.board.forEach((piece, cell) => {
+            if (piece.animal === "Tiger") {
+                result.set(cell, piece.facingDirection);
+            }
+        })
+        return result;
+    }
+
+    public placeGoat(cell: string) {
+        if (!this.emptyCells().includes(cell)) {
+            throw new Error("Cannot place goat on non-empty cell.");
+        }
+        this.board.set(cell, {owner: 1, animal: "Goat", facingDirection: "N"}); // Goats by default face north, but their direction is irrelevant.
+        this.goatsInHand -= 1;
+    }
+
+    public newDirection(from: string, to: string): Direction {
+        const pair = new BaghChalCellPair(from, to);
+
+        const direction = RectGrid.bearing(pair.fromX(), pair.fromY(), pair.toX(), pair.toY());
+        if (direction === undefined) {
+            throw Error("No valid facing direction after move!");
+        } else {
+            return direction;
+        }
+    }
+
+    public executeMove(from: string, to: string) {
+        const oldPiece = this.board.get(from);
+        if (oldPiece === undefined) {
+            throw Error("No piece here to move!");
+        }
+
+        const pair = new BaghChalCellPair(from, to);
+        const [dX, dY] = pair.deltaVector();
+        if ((Math.abs(dX) === 2) || (Math.abs(dY) === 2)) {
+            // Jump & capture
+            const [preyX, preyY] = [pair.fromX() + Math.sign(dX), pair.fromY() + Math.sign(dY)];
+            const prey = BaghChalGame.coords2algebraic(preyX, preyY);
+            this.board.delete(prey);
+            this.goatsCaptured += 1;
+        }
+
+        const newPiece = { owner: oldPiece.owner, animal: oldPiece.animal, facingDirection: this.newDirection(from, to) };
+        this.board.delete(from);
+        this.board.set(to, newPiece);
+    }
+
+    public jumpsAvailable(from: string) {
+        const piece = this.board.get(from);
+        if (piece === undefined) {
+            throw Error("No piece here to move!");
+        }
+        if (piece.animal !== "Tiger") {
+            throw Error("No tiger here to move!");
+        }
+        const prey = this.graph.neighbours(from)
+            .filter((nb) => {return this.board.has(nb);})
+            .filter((nb) => {return this.board.get(nb)!.animal === "Goat";});
+        const pairs = prey.map((nb) => {return new BaghChalCellPair(from, nb);})
+            .filter((pair) => {
+                const actual = pair.direction();
+                const allowed = allowedDirections(piece.facingDirection);
+                return (actual !== undefined && allowed.includes(actual));
+            });
+        const targets = pairs.map((pair) => {
+            const [dX, dY] = pair.deltaVector();
+            const [tarX, tarY] = [pair.toX() + dX, pair.toY() + dY];
+            try {
+                const target = BaghChalGame.coords2algebraic(tarX, tarY);
+                return target;
+            } catch (err) {
+                if (
+                    (err instanceof Error)
+                    &&
+                    (err.message.startsWith("Could not find a character at index"))
+                ){
+                    // Hypothetical target is out of bounds of grid
+                    return "OutOfBounds";
+                }
+                else {
+                    throw Error("Unexpected error in calculating jump target.")
+                }
+            }
+        }).filter((target) => {
+            return (target !== "OutOfBounds");
+        }).filter((target) => {
+            return (this.graph.graph.nodes().includes(target)) && (!this.board.has(target));
+        });
+        return targets.map((target) => from + "-" + target);
+    }
+
+    private phase(): Phase {
+        if (this.currplayer === 2) {
+            return "TigerMovement";
+        } else if (this.goatsInHand > 0) {
+            return "GoatPlacement";
+        } else {
+            return "GoatMovement";
+        }
+    }
+
+    public moves(): string[] {
+        if (this.gameover) { return []; }
+
+        if (this.phase() === "GoatPlacement") {
+            return this.emptyCells();
+        }
+
+        else if (this.phase() === "GoatMovement") {
+            const moves: string[] = [];
+            this.goatsOnBoard().forEach((cell) => {
+                this.graph.neighbours(cell).forEach((nb) => {
+                    if (!this.board.has(nb)) {
+                        moves.push(cell + "-" + nb);
+                    }
+                });
+            });
+
+            return moves;
+        }
+
+        else if (this.phase() === "TigerMovement") {
+            const simpleMoves: string[] = [];
+            this.tigersOnBoard().forEach((direction, cell) => {
+                this.graph.neighbours(cell).forEach((nb) => {
+                    if (!this.board.has(nb)) {
+                        simpleMoves.push(cell + "-" + nb);
+                    }
+                });
+            });
+            const jumpMoves: string[] = [];
+            this.tigersOnBoard().forEach((direction, cell) => {
+                const jumps = this.jumpsAvailable(cell);
+                jumpMoves.push(...jumps);
+            });
+            return simpleMoves.concat(jumpMoves);
+        }
+
+        else {
+            return [];
+        }
+    }
+
+
+
+    public handleClick(move: string, row: number, col: number, piece?: string): IClickResult {
+        try {
+            const cell = BaghChalGame.coords2algebraic(col, row);
+            let newmove = "";
+
+
+            if (move === "") {
+                newmove = cell;
+            } else {
+                if (cell === move) {
+                    newmove = "";
+                } else if (this.board.has(cell) && this.board.get(cell)!.owner === this.currplayer) {
+                    newmove = cell;
+                } else {
+                    newmove = `${move}-${cell}`;
+                }
+            }
+
+            const result = this.validateMove(newmove) as IClickResult;
+            if (!result.valid) {
+                result.move = "";
+            } else {
+                result.move = newmove;
+            }
+            return result;
+        } catch (e) {
+            return {
+                move,
+                valid: false,
+                message: i18next.t("apgames:validation._general.GENERIC", { move, row, col, piece, emessage: (e as Error).message })
+            }
+        }
+    }
+
+
+
+    public validateMove(m: string): IValidationResult {
+        const result: IValidationResult = { valid: false, message: i18next.t("apgames:validation._general.DEFAULT_HANDLER") };
+
+        const validMoves = this.moves();
+        const validStarts = validMoves.map((vm) => {return vm.split("-")[0]});
+
+        if (m.length === 0) {
+            result.valid = true;
+            result.complete = -1;
+            if (this.phase() === "TigerMovement") {
+                result.message = i18next.t("apgames:validation.baghchal.INITIAL_INSTRUCTIONS_TIGER_MOVEMENT");
+            } else if (this.phase() === "GoatMovement") {
+                result.message = i18next.t("apgames:validation.baghchal.INITIAL_INSTRUCTIONS_GOAT_MOVEMENT");
+            } else if (this.phase() === "GoatPlacement") {
+                result.message = i18next.t("apgames:validation.baghchal.INITIAL_INSTRUCTIONS_GOAT_PLACEMENT");
+            }
+            return result;
+        }
+
+        if (validMoves.includes(m)) {
+            result.valid = true;
+            result.complete = 1;
+            result.message = i18next.t("apgames:validation._general.VALID_MOVE");
+            return result;
+        }
+        if (validStarts.includes(m)) {
+            result.valid = true;
+            result.complete = -1
+            result.message = i18next.t("apgames:validation.baghchal.VALID_PARTIAL");
+            return result;
+        }
+
+        result.valid = false;
+        result.message = i18next.t("apgames:validation._general.INVALID_MOVE", { move: m });
+        return result;
+    }
+
+
+    public move(m: string, { partial = false, trusted = false } = {}): BaghChalGame {
+        if (this.gameover) {
+            throw new UserFacingError("MOVES_GAMEOVER", i18next.t("apgames:MOVES_GAMEOVER"));
+        }
+
+        m = m.toLowerCase();
+        m = m.replace(/\s+/g, "");
+
+        if (!trusted) {
+            const result = this.validateMove(m);
+            if (!result.valid) {
+                throw new UserFacingError("VALIDATION_GENERAL", result.message)
+            }
+            if ((!partial) && (!this.moves().includes(m))) {
+                throw new UserFacingError("VALIDATION_FAILSAFE", i18next.t("apgames:validation._general.FAILSAFE", { move: m }))
+            }
+        }
+
+        if (partial && !m.includes("-")) {
+            const start = m;
+            const validMoves = this.moves()
+                .filter((vm) => { return vm.split("-")[0] === start});
+            const validEnds = validMoves
+                 .map((vm) => { return vm.split("-")[1] });
+            this._points = validEnds.map((ve) => {return BaghChalGame.algebraic2coords(ve);});
+            return this;
+        } else {
+            this._points = [];
+        }
+
+        if (m.length === 2) {
+            // Placement
+            this.placeGoat(m);
+        }
+        else {
+            // Move
+            const [from, to] = m.split("-");
+            this.executeMove(from, to);
+        }
+        this.results = [];
+
+
+
+        this.lastmove = m;
+        const newplayer = ((this.currplayer as number)  % 2) + 1;
+        this.currplayer = newplayer as playerid;
+
+
+        this.checkEOG();
+        this.saveState();
+        return this;
+    }
+
+
+
+    protected checkEOG(): BaghChalGame {
+        if (this.goatsCaptured === 5) {
+            this.winner = [2];
+            this.gameover = true;
+        }
+
+        if (this.moves().length === 0) {
+            const winner = ((this.currplayer as number) % 2) + 1;
+            this.winner = [winner as playerid];
+            this.gameover = true;
+        }
+
+        if (this.gameover) {
+            this.results.push(
+                { type: "eog" },
+                { type: "winners", players: [...this.winner] }
+            );
+        }
+        return this;
+    }
+
+
+
+    public state(): IBaghChalState {
+        return {
+            game: BaghChalGame.gameinfo.uid,
+            numplayers: this.numplayers,
+            variants: this.variants,
+            gameover: this.gameover,
+            winner: [...this.winner],
+            stack: [...this.stack]
+        };
+    }
+
+
+    public moveState(): IMoveState {
+        return {
+            _version: BaghChalGame.gameinfo.version,
+            _results: [...this.results],
+            _timestamp: new Date(),
+            currplayer: this.currplayer,
+            lastmove: this.lastmove,
+            board: new Map(this.board),
+            goatsInHand: this.goatsInHand,
+            goatsCaptured: this.goatsCaptured,
+        };
+    }
+
+    public render(): APRenderRep {
+        // Build piece string
+        let pstr = "";
+        for (let row = 0; row < 5; row++) {
+            if (pstr.length > 0) {
+                pstr += "\n";
+            }
+            const pieces: string[] = [];
+            for (let col = 0; col < 5; col++) {
+                const cell = BaghChalGame.coords2algebraic(col, row);
+                if (this.board.has(cell)) {
+                    const contents = this.board.get(cell)!;
+                    if (contents.animal === "Tiger") {
+                        pieces.push("T" + contents.facingDirection + ",");
+                    }
+                    else {
+                        pieces.push("G,");
+                    }
+                }
+                else {
+                    pieces.push("-,");
+                }
+            }
+            pstr += pieces.join("");
+        }
+        pstr = pstr.replace(/(-,){5}/g, "_");
+
+        // Build rep
+        const rep: APRenderRep = {
+            board: {
+                style: "vertex-fanorona",
+                width: 5,
+                height: 5,
+            },
+            legend: {
+                G: {
+                    name: "piece",
+                    colour: 1
+                },
+                TN: {
+                    name: "piece-triangle",
+                    rotate: 0,
+                    colour: 2
+                },
+                TNE: {
+                    name: "piece-triangle",
+                    rotate: 45,
+                    colour: 2
+                },
+                TE: {
+                    name: "piece-triangle",
+                    rotate: 90,
+                    colour: 2
+                },
+                TSE: {
+                    name: "piece-triangle",
+                    rotate: 135,
+                    colour: 2
+                },
+                TS: {
+                    name: "piece-triangle",
+                    rotate: 180,
+                    colour: 2
+                },
+                TSW: {
+                    name: "piece-triangle",
+                    rotate: 225,
+                    colour: 2
+                },
+                TW: {
+                    name: "piece-triangle",
+                    rotate: 270,
+                    colour: 2
+                },
+                TNW: {
+                    name: "piece-triangle",
+                    rotate: 315,
+                    colour: 2
+                }
+            },
+            pieces: pstr
+        };
+
+        rep.annotations = [];
+
+        if (this._points.length > 0) {
+            const points = [];
+            for (const [x, y] of this._points) {
+                points.push({ row: y, col: x });
+            }
+            rep.annotations.push({
+                type: "dots",
+                targets: points as [{ row: number; col: number; }, ...{ row: number; col: number; }[]]
+            });
+        }
+
+        return rep;
+    }
+
+    public getPlayerStash(player: number): IStashEntry[] | undefined {
+        if (player === 1) {
+            return [{ count: this.goatsInHand, glyph: { name: "piece", colour: player }, movePart: "" }];
+        }
+        else {
+            return [{ count: this.goatsCaptured, glyph: { name: "star-outline", colour: player }, movePart: "" }];
+        }
+    }
+
+
+
+    public clone(): BaghChalGame {
+        return new BaghChalGame(this.serialize());
+    }
+
+
+}

--- a/src/games/baghchal.ts
+++ b/src/games/baghchal.ts
@@ -149,8 +149,12 @@ export class BaghChalGame extends GameBase {
             "mechanic>move",
             "mechanic>capture",
             "mechanic>asymmetry",
+            "board>shape>rect",
+            "board>connect>rect",
+            "components>simple>1per",
         ],
         flags: [
+            "experimental",
             "player-stashes",
         ]
     };

--- a/test/games/baghchal.test.ts
+++ b/test/games/baghchal.test.ts
@@ -1,0 +1,165 @@
+import "mocha";
+import { expect } from "chai";
+import { BaghChalGame } from '../../src/games';
+import { BaghChalCellPair, allowedDirections } from "../../src/games/baghchal";
+
+
+// const allCells: string[] = [
+//     "a1", "a2", "a3", "a4", "a5",
+//     "b1", "b2", "b3", "b4", "b5",
+//     "c1", "c2", "c3", "c4", "c5",
+//     "d1", "d2", "d3", "d4", "d5",
+//     "e1", "e2", "e3", "e4", "e5",
+// ]
+
+const initiallyEmptyCells: string[] = [
+          "a2", "a3", "a4",
+    "b1", "b2", "b3", "b4", "b5",
+    "c1", "c2", "c3", "c4", "c5",
+    "d1", "d2", "d3", "d4", "d5",
+          "e2", "e3", "e4",
+]
+
+
+describe("BaghChal", () => {
+    it ("Cell pairs", () => {
+        const pair1 = new BaghChalCellPair("a1", "a2");
+        expect(pair1.fromX()).to.eql(0);
+        expect(pair1.fromY()).to.eql(4);
+        expect(pair1.toX()).to.eql(0);
+        expect(pair1.toY()).to.eql(3);
+        expect(pair1.deltaX()).to.eql(0);
+        expect(pair1.deltaY()).to.eql(-1);
+        expect(pair1.deltaString()).to.eql("0|-1");
+        expect(pair1.direction()).to.eql("N");
+
+        const pair2 = new BaghChalCellPair("c3", "d4");
+        expect(pair2.deltaString()).to.eql("1|-1");
+        expect(pair2.direction()).to.eql("NE");
+
+        const pair3 = new BaghChalCellPair("a4", "b4");
+        expect(pair3.deltaString()).to.eql("1|0");
+        expect(pair3.direction()).to.eql("E");
+
+        const pair4 = new BaghChalCellPair("d4", "e3");
+        expect(pair4.deltaString()).to.eql("1|1");
+        expect(pair4.direction()).to.eql("SE");
+
+        const pair5 = new BaghChalCellPair("c3", "c2");
+        expect(pair5.deltaString()).to.eql("0|1");
+        expect(pair5.direction()).to.eql("S");
+
+        const pair6 = new BaghChalCellPair("e5", "d4");
+        expect(pair6.deltaString()).to.eql("-1|1");
+        expect(pair6.direction()).to.eql("SW");
+
+        const pair7 = new BaghChalCellPair("b2", "a2");
+        expect(pair7.deltaString()).to.eql("-1|0");
+        expect(pair7.direction()).to.eql("W");
+
+        const pair8 = new BaghChalCellPair("c1", "b2");
+        expect(pair8.deltaString()).to.eql("-1|-1");
+        expect(pair8.direction()).to.eql("NW");
+    });
+    it ("Initial empty cells", () => {
+        const g = new BaghChalGame();
+        expect(g.emptyCells()).to.have.members(initiallyEmptyCells);
+    });
+    it ("Place goat", () => {
+        const g = new BaghChalGame();
+        g.placeGoat("b4");
+        expect(g.goatsOnBoard()).to.eql(["b4"]);
+        expect(g.goatsInHand).to.eql(19);
+    });
+    it ("Last goat placement, first goat move", () => {
+        const g = new BaghChalGame();
+        g.goatsInHand = 1;
+        g.move("c4");
+        expect(g.goatsInHand).to.eql(0);
+        g.move("a1-b1")
+        expect(g.moves()).to.have.members(["c4-c5", "c4-b4", "c4-d4", "c4-c3"]);
+    });
+    it("Allowed tiger jump directions", () => {
+        expect(allowedDirections("N")).to.have.members(["W", "NW", "N", "NE", "E"]);
+        expect(allowedDirections("NE")).to.have.members(["NW", "N", "NE", "E", "SE"]);
+        expect(allowedDirections("E")).to.have.members(["N", "NE", "E", "SE", "S"]);
+        expect(allowedDirections("SE")).to.have.members(["NE", "E", "SE", "S", "SW"]);
+        expect(allowedDirections("S")).to.have.members(["E", "SE", "S", "SW", "W"]);
+        expect(allowedDirections("SW")).to.have.members(["SE", "S", "SW", "W", "NW"]);
+        expect(allowedDirections("W")).to.have.members(["S", "SW", "W", "NW", "N"]);
+        expect(allowedDirections("NW")).to.have.members(["SW", "W", "NW", "N", "NE"]);
+    });
+    it("Partial move annotations", () => {
+        const g = new BaghChalGame();
+
+        g.move("c4"); // Full goat placement
+        const render1 = g.render()
+        expect(render1.annotations).to.eql([]);
+
+        g.move("a5", { partial: true, trusted: false }); // Tiger selected
+        const render2 = g.render()
+        expect(render2.annotations![0]).to.eql({
+            type: 'dots',
+            targets: [{ row: 0, col: 1 }, { row: 1, col: 0 }, { row: 1, col: 1 }]
+        })
+
+        g.move("a5-a4"); // Tiger moved
+        const render3 = g.render()
+        expect(render3.annotations).to.eql([]);
+    });
+    it ("Example game", () => {
+        const g = new BaghChalGame();
+
+        expect(g.tigersOnBoard()).to.eql(new Map([
+            ["a1", "NE" ],
+            ["a5", "SE" ],
+            ["e1", "NW" ],
+            ["e5", "SW" ],
+        ]));
+
+        expect(g.goatsOnBoard()).to.eql([]);
+        expect(g.goatsInHand).to.eql(20);
+
+
+        expect(g.currplayer === 1);
+        // Place goat
+        g.move("b4");
+        expect(g.goatsOnBoard()).to.eql(["b4"]);
+        expect(g.goatsInHand).to.eql(19);
+
+
+        expect(g.currplayer === 2);
+        // Simple tiger move
+        g.move("a1-b1");
+
+        expect(g.tigersOnBoard()).to.eql(new Map([
+            ["b1", "E"],
+            ["a5", "SE"],
+            ["e1", "NW"],
+            ["e5", "SW"],
+        ]));
+
+
+        expect(g.currplayer === 1);
+        // Place goat
+        g.move("e3");
+        expect(g.goatsOnBoard()).to.have.members(["b4", "e3"]);
+        expect(g.goatsInHand).to.eql(18);
+
+        expect(g.currplayer === 2);
+
+        expect(g.goatsCaptured).to.eql(0);
+        // Tiger jumps and captures goat on b4
+        g.move("a5-c3");
+        expect(g.goatsCaptured).to.eql(1);
+
+        expect(g.tigersOnBoard()).to.eql(new Map([
+            ["b1", "E"],
+            ["c3", "SE"],
+            ["e1", "NW"],
+            ["e5", "SW"],
+        ]));
+
+        expect(g.goatsOnBoard()).to.have.members(["e3"]);
+    })
+});


### PR DESCRIPTION
I added Bagh Chal:

4 tigers (triangles) try to capture 5 of the goats (circles). All 20 goats start in hand of player 1, tigers start on the corners of the board, facing towards the center.

The triangles show the tigers' facing direction, which changes after a move into the move direction.

Since only player 2 (the tiger player) can 'score' by capturing goats, I decided not to add a score board, but instead show goats in hand as well as goats captured in the stash, the latter as stars in the tiger player's color.

The game logic works correctly - I tested the move patterns, win conditions and the stash.

The game knows all possible moves at a given position. However, I did not manage to mark the possible moves of a piece with dots. The APRenderRep contains the – afaik – correct annotations though.
